### PR TITLE
FIxes Issue #58

### DIFF
--- a/Drivers/ProductAttributesPartDriver.cs
+++ b/Drivers/ProductAttributesPartDriver.cs
@@ -87,7 +87,7 @@ namespace Nwazet.Commerce.Drivers {
         protected override DriverResult Editor(ProductAttributesPart part, IUpdateModel updater, dynamic shapeHelper) {
             var editViewModel = new ProductAttributesEditViewModel();
             if (updater.TryUpdateModel(editViewModel, Prefix, null, null)) {
-                part.AttributeIds = editViewModel.AttributeIds;
+                part.AttributeIds = _attributeService.GetAttributes(editViewModel.AttributeIds).Select(pap => pap.Id);
             }
             return Editor(part, shapeHelper);
         }

--- a/Services/ProductAttributeService.cs
+++ b/Services/ProductAttributeService.cs
@@ -33,7 +33,7 @@ namespace Nwazet.Commerce.Services {
 
         public IEnumerable<ProductAttributePart> GetAttributes(IEnumerable<int> ids) {
             var attributes = AttributesById;
-            return ids.Select(id => attributes[id]).ToList();
+            return ids.Where(id => attributes.ContainsKey(id)).Select(id => attributes[id]).ToList();
         }
     }
 }


### PR DESCRIPTION
Fixes #58 
The buttons were not displayed because of an exception in the GetAttributes method from the ProductAttributeService.

I fixed that code to handle the case where Attributes have been deleted.
I also added code to the ProductAttributesPartDriver, so that when the Part is saved, any deleted attributes are removed from the record.