### PR TITLE
Fixes in part issue 51

### DIFF
--- a/Controllers/ShoppingCartController.cs
+++ b/Controllers/ShoppingCartController.cs
@@ -30,6 +30,8 @@ namespace Nwazet.Commerce.Controllers {
         private readonly INotifier _notifier;
         private readonly IEnumerable<IProductAttributeExtensionProvider> _attributeExtensionProviders;
 
+        public Localizer T { get; set; }
+
         private const string AttributePrefix = "productattributes.a";
         private const string ExtensionPrefix = "ext.";
 
@@ -55,6 +57,8 @@ namespace Nwazet.Commerce.Controllers {
             _workflowManager = workflowManager;
             _notifier = notifier;
             _attributeExtensionProviders = attributeExtensionProviders;
+
+            T = NullLocalizer.Instance;
         }
 
         [HttpPost]
@@ -89,10 +93,31 @@ namespace Nwazet.Commerce.Controllers {
                     });
 
             // Retrieve minimum order quantity
+            Dictionary<int, string> productMessages = new Dictionary<int, string>();
             var productPart = _contentManager.Get<ProductPart>(id);
+            string productTitle = _contentManager.GetItemMetadata(productPart.ContentItem).DisplayText;
             if (productPart != null) {
-                if (quantity < productPart.MinimumOrderQuantity)
+                if (quantity < productPart.MinimumOrderQuantity) {
                     quantity = productPart.MinimumOrderQuantity;
+                    if (productMessages.ContainsKey(id)) {
+                        productMessages[id] = String.Format("{0}{1}{2}", productMessages[id], Environment.NewLine,
+                            T("Quantity increased to match minimum possible for {0}.", productTitle).Text);
+                    }
+                    else {
+                        productMessages.Add(id, T("Quantity increased to match minimum possible for {0}.", productTitle).Text);
+                    }
+                }
+                //only add to cart if there are at least as many available products as the requested quantity
+                if (quantity > productPart.Inventory && !productPart.AllowBackOrder) {
+                    quantity = productPart.Inventory;
+                    if (productMessages.ContainsKey(id)) {
+                        productMessages[id] = String.Format("{0}{1}{2}", productMessages[id], Environment.NewLine,
+                            T("Quantity decreased to match inventory for {0}.", productTitle).Text);
+                    }
+                    else {
+                        productMessages.Add(id, T("Quantity decreased to match inventory for {0}.", productTitle).Text);
+                    }
+                }
             }
 
             _shoppingCart.Add(id, quantity, productattributes);
@@ -107,14 +132,14 @@ namespace Nwazet.Commerce.Controllers {
             if (Request.IsAjaxRequest() || isAjaxRequest) {
                 return new ShapePartialResult(
                     this,
-                    BuildCartShape(true, _shoppingCart.Country, _shoppingCart.ZipCode));
+                    BuildCartShape(true, _shoppingCart.Country, _shoppingCart.ZipCode, null, productMessages));
             }
-            return RedirectToAction("Index");
+            return RedirectToAction("Index", productMessages);
         }
 
         [Themed]
         [OutputCache(Duration = 0)]
-        public ActionResult Index() {
+        public ActionResult Index(Dictionary<int, string> productMessages = null) {
             _wca.GetContext().Layout.IsCartPage = true;
             try {
                 return new ShapeResult(
@@ -123,8 +148,9 @@ namespace Nwazet.Commerce.Controllers {
                         false,
                         _shoppingCart.Country,
                         _shoppingCart.ZipCode,
-                        _shoppingCart.ShippingOption));
-            } 
+                        _shoppingCart.ShippingOption,
+                        productMessages));
+            }
             catch (ShippingException ex) {
                 _shoppingCart.Country = null;
                 _shoppingCart.ZipCode = null;
@@ -138,7 +164,8 @@ namespace Nwazet.Commerce.Controllers {
             bool isSummary = false,
             string country = null,
             string zipCode = null,
-            ShippingOption shippingOption = null) {
+            ShippingOption shippingOption = null,
+            Dictionary<int,string> productMessages = null) {
 
             var shape = _shapeFactory.ShoppingCart();
 
@@ -151,7 +178,7 @@ namespace Nwazet.Commerce.Controllers {
                 .GetProducts()
                 .Where(p => p.Quantity > 0)
                 .ToList();
-            var productShapes = GetProductShapesFromQuantities(productQuantities);
+            var productShapes = GetProductShapesFromQuantities(productQuantities, productMessages);
             shape.ShopItems = productShapes;
 
             var shopItemsAllDigital = !(productQuantities.Any(pq => !(pq.Product.IsDigital)));
@@ -196,7 +223,10 @@ namespace Nwazet.Commerce.Controllers {
                     displayCheckoutButtons = false;
                 }
             }
-
+            if (displayCheckoutButtons) {
+                //check whether back-order is allowed for products whose inventory is less than the requested quantity
+                displayCheckoutButtons = !productQuantities.Any(pq => pq.Quantity > pq.Product.Inventory && !pq.Product.AllowBackOrder);
+            }
             if (displayCheckoutButtons) {
                 var checkoutShapes = _checkoutServices.Select(
                     service => service.BuildCheckoutButtonShape(
@@ -210,6 +240,8 @@ namespace Nwazet.Commerce.Controllers {
                 shape.CheckoutButtons = checkoutShapes;
             }
 
+            
+
             shape.Subtotal = subtotal;
             shape.Taxes = taxes;
             shape.Total = _shoppingCart.Total(subtotal, taxes);
@@ -220,7 +252,8 @@ namespace Nwazet.Commerce.Controllers {
         }
 
         private IEnumerable<dynamic> GetProductShapesFromQuantities(
-            IEnumerable<ShoppingCartQuantityProduct> productQuantities) {
+            IEnumerable<ShoppingCartQuantityProduct> productQuantities,
+            Dictionary<int, string> productMessages = null) {
             var productShapes = productQuantities.Select(
                 productQuantity => _shapeFactory.ShoppingCartItem(
                     Quantity: productQuantity.Quantity,
@@ -238,7 +271,11 @@ namespace Nwazet.Commerce.Controllers {
                     Promotion: productQuantity.Promotion,
                     ShippingCost: productQuantity.Product.ShippingCost,
                     Weight: productQuantity.Product.Weight,
-                    MinimumOrderQuantity: productQuantity.Product.MinimumOrderQuantity)).ToList();
+                    MinimumOrderQuantity: productQuantity.Product.MinimumOrderQuantity,
+                    Messages: productMessages == null ? (string)null : productMessages.ContainsKey(productQuantity.Product.Id) ? productMessages[productQuantity.Product.Id] : (string)null,
+                    Inventory: productQuantity.Product.Inventory,
+                    AllowBackOrder: productQuantity.Product.AllowBackOrder
+                    )).ToList();
             return productShapes;
         }
 
@@ -250,7 +287,7 @@ namespace Nwazet.Commerce.Controllers {
                         true,
                         _shoppingCart.Country,
                         _shoppingCart.ZipCode));
-            } 
+            }
             catch (ShippingException ex) {
                 _shoppingCart.Country = null;
                 _shoppingCart.ZipCode = null;
@@ -294,7 +331,7 @@ namespace Nwazet.Commerce.Controllers {
                         true,
                         _shoppingCart.Country,
                         _shoppingCart.ZipCode));
-            } 
+            }
             catch (ShippingException ex) {
                 _shoppingCart.Country = null;
                 _shoppingCart.ZipCode = null;
@@ -365,7 +402,7 @@ namespace Nwazet.Commerce.Controllers {
                         var product = products.Where(p => p.Id == item.ProductId).FirstOrDefault();
                         if (product != null) {
                             minimumOrderQuantites.Add(product.Id, product.MinimumOrderQuantity);
-                        } 
+                        }
                         else {
                             // This ensures the dictionary will have all the keys needed for the items
                             minimumOrderQuantites.Add(item.ProductId, defaultMinimumQuantity);

--- a/Drivers/ProductAttributesPartDriver.cs
+++ b/Drivers/ProductAttributesPartDriver.cs
@@ -87,7 +87,7 @@ namespace Nwazet.Commerce.Drivers {
         protected override DriverResult Editor(ProductAttributesPart part, IUpdateModel updater, dynamic shapeHelper) {
             var editViewModel = new ProductAttributesEditViewModel();
             if (updater.TryUpdateModel(editViewModel, Prefix, null, null)) {
-                part.AttributeIds = editViewModel.AttributeIds;
+                part.AttributeIds = _attributeService.GetAttributes(editViewModel.AttributeIds).Select(pap => pap.Id);
             }
             return Editor(part, shapeHelper);
         }

--- a/Drivers/ProductAttributesPartDriver.cs
+++ b/Drivers/ProductAttributesPartDriver.cs
@@ -58,7 +58,11 @@ namespace Nwazet.Commerce.Drivers {
             // If the part isn't there, there must be no attributes
             if (attributesPart == null) return attributeIdsToValues == null || !attributeIdsToValues.Any();
             // If the part is there, it must have as many attributes as were passed in
-            if (attributesPart.AttributeIds.Count() != attributeIdsToValues.Count) return false;
+            if (attributesPart.AttributeIds.Count() != attributeIdsToValues.Count) {
+                //Attributes may have been deleted
+                attributesPart.AttributeIds = _attributeService.GetAttributes(attributeIdsToValues.Keys).Select(pap => pap.Id);
+                if (attributesPart.AttributeIds.Count() != attributeIdsToValues.Count) return false;
+            }
             // The same attributes must be present
             if (!attributesPart.AttributeIds.All(attributeIdsToValues.ContainsKey)) return false;
             // Get the actual attributes in order to verify the values

--- a/Services/ProductAttributeService.cs
+++ b/Services/ProductAttributeService.cs
@@ -33,7 +33,7 @@ namespace Nwazet.Commerce.Services {
 
         public IEnumerable<ProductAttributePart> GetAttributes(IEnumerable<int> ids) {
             var attributes = AttributesById;
-            return ids.Select(id => attributes[id]).ToList();
+            return ids.Where(id => attributes.ContainsKey(id)).Select(id => attributes[id]).ToList();
         }
     }
 }

--- a/Views/Parts/Product.AddButton.cshtml
+++ b/Views/Parts/Product.AddButton.cshtml
@@ -24,7 +24,7 @@
     
     <div class="addtocart-quantity-and-button">
         <input name="id" value="@productId" type="hidden"/>
-        <input name="quantity" value="@quantityValue" class="addtocart-quantity" type="number" min="0" />
+        <input name="quantity" value="@quantityValue" class="addtocart-quantity" type="number" min="@Model.MinimumOrderQuantity" />
         <button type="submit" class="addtocart-button">@T("Add to cart")</button>
         @if ((int)Model.MinimumOrderQuantity > 1) {
             <br /><strong>Minimum order of @Model.MinimumOrderQuantity required.</strong>

--- a/Views/ShoppingCart.Summary.cshtml
+++ b/Views/ShoppingCart.Summary.cshtml
@@ -1,13 +1,22 @@
 ﻿@using Nwazet.Commerce.Models
 @using Orchard.ContentManagement
 @{
-    var items = (IList<dynamic>) Model.ShopItems;
-    var subtotal = (decimal) Model.Subtotal;
+    var items = (IList<dynamic>)Model.ShopItems;
+    var subtotal = (decimal)Model.Subtotal;
     var root = HttpContext.Current.Request.ApplicationPath;
-    var cartUrl = Url.Action("Index", "ShoppingCart", new {area = "NWazet.Commerce"});
+    var cartUrl = Url.Action("Index", "ShoppingCart", new { area = "NWazet.Commerce" });
+    if (items.Any(it => !string.IsNullOrEmpty(it.Messages))) {
+        string allMessages = string.Join(Environment.NewLine, items.Where(it => !string.IsNullOrEmpty(it.Messages)).Select(it => it.Messages));
+        <div id="product-update-messages" class="message-Information">
+            @allMessages
+        </div>
+    }
+    else {
+        <div id="shopping-cart-notification" class="message-Information hide"></div>
+    }
     if (items.Any()) {
-        using (Html.BeginFormAntiForgeryPost(Url.Action("AjaxUpdate", "ShoppingCart", new {area = "Nwazet.Commerce"}), FormMethod.Post,
-            new Dictionary<string, object> {{"enctype", "multipart/form-data"}})) {
+        using (Html.BeginFormAntiForgeryPost(Url.Action("AjaxUpdate", "ShoppingCart", new { area = "Nwazet.Commerce" }), FormMethod.Post,
+            new Dictionary<string, object> { { "enctype", "multipart/form-data" } })) {
             @Html.Hidden("Country", (string) Model.Country)
             @Html.Hidden("ZipCode", (string) Model.ZipCode)
             <h1><a href="@cartUrl">@T("Your Cart")</a></h1>
@@ -26,6 +35,7 @@
                     var unitPrice = (double) item.DiscountedPrice;
                     var totalPrice = quantity*unitPrice;
                     var minimumOrderQuantity = item.MinimumOrderQuantity;
+                    var productInventory = (int)item.Inventory;
                     <li>
                         @if (imageUrl != null) {
                             <a href="@Url.ItemDisplayUrl(contentItem)" class="product-image-link"><img src="@Href(imageUrl)" alt="@title" class="product-image"/></a>
@@ -50,6 +60,11 @@
                             <input name="@(propertyNamePrefix + ".ProductId")" type="hidden" value="@product.Id" />
                             <span class="numeric">
                                 <input name="@(propertyNamePrefix + ".Quantity")" type="number" class="quantity addtocart-quantity" value="@quantity" min="0" />
+                                @if (quantity > productInventory) {
+                                    <span class="issue">
+                                        @T("Only {0} in stock. {1}.", productInventory, (bool)item.AllowBackOrder ? T("Back order is allowed"):T("Back order is not allowed") )
+                                    </span>
+                                }
                             </span>
                             <span class="numeric">@totalPrice.ToString("c")</span>
                             @if (minimumOrderQuantity > 1) {
@@ -64,10 +79,12 @@
                 <span class="numeric label">@T("Subtotal:")</span>
                 <span class="numeric subtotal">@subtotal.ToString("c")</span>
             </div>
-            <span class="explanation">@T("Tax and shipping will be calculated at checkout.")</span>
-            <div class="checkout">
-                <a class="button" href="@cartUrl">Checkout</a>
-            </div>
+            if (Model.CheckoutButtons != null) {
+                <span class="explanation">@T("Tax and shipping will be calculated at checkout.")</span>
+                <div class="checkout">
+                    <a class="button" href="@cartUrl">Checkout</a>
+                </div>
+            }
         }
     }
 }

--- a/Views/ShoppingCart.cshtml
+++ b/Views/ShoppingCart.cshtml
@@ -9,7 +9,15 @@
     var readOnly = Model.ReadOnly != null && Model.ReadOnly == true;
 }
 <article class="shoppingcart">
-    <div id="shopping-cart-notification" class="message-Information hide"></div>
+    @if (items.Any(it => !string.IsNullOrEmpty(it.Messages))) {
+        string allMessages =string.Join(Environment.NewLine, items.Where(it => !string.IsNullOrEmpty(it.Messages)));
+        <div id="shopping-cart-notification" class="message-Information">
+            @allMessages
+        </div>
+    }
+    else {
+        <div id="shopping-cart-notification" class="message-Information hide"></div>
+    }
     @using (Html.BeginFormAntiForgeryPost(Url.Action("Update", "ShoppingCart", new { area = "Nwazet.Commerce" }))) {
         if (!items.Any()) {
             <p class="shopping-cart-container" data-got-cart="false">
@@ -53,6 +61,7 @@
                             var linePriceAdjustment = (double)item.LinePriceAdjustment;
                             var totalPrice = quantity * unitPrice + linePriceAdjustment;
                             var minimumOrderQuantity = item.MinimumOrderQuantity;
+                            var productInventory = (int)item.Inventory;
 
                             string originalUnitPrice = "";
                             if (unitPrice != unitPriceOriginal && unitPriceOriginal != 0.0) {
@@ -92,6 +101,11 @@
                                         }
                                         <input name="@(propertyNamePrefix + ".ProductId")" type="hidden" value="@product.Id" />
                                         <input name="@(propertyNamePrefix + ".Quantity")" type="number" class="quantity addtocart-quantity" value="@quantity" min="0" />
+                                        if (quantity > productInventory) {
+                                            <span class="issue">
+                                                @T("Only {0} in stock. {1}.", productInventory, (bool)item.AllowBackOrder ? T("Back order is allowed") : T("Back order is not allowed"))
+                                            </span>
+                                        }
                                     }
                                 </td>
                                 <td class="numeric amount">@totalPrice.ToString("c")</td>


### PR DESCRIPTION
- Server-side check so that when you add products to the cart, if you are trying to add more than however many are available, it will only add the available quantity, unless back-order is allowed.
- If you still wish to increase the quantity in order, you can. In the cart views, beside the number, you will have a string telling you how many are in stock, and whether back-order is allowed.
- If you have in the cart out of stock product, the checkout buttons will not show.