### PR TITLE
Sku enhancements

### DIFF
--- a/Controllers/ECommerceSettingsAdminController .cs
+++ b/Controllers/ECommerceSettingsAdminController .cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Mvc;
+using Nwazet.Commerce.Permissions;
+using Orchard;
+using Orchard.ContentManagement;
+using Orchard.Localization;
+using Orchard.Settings;
+using Orchard.UI.Admin;
+using Orchard.UI.Notify;
+
+namespace Nwazet.Commerce.Controllers {
+    [ValidateInput(false), Admin]
+    public class ECommerceSettingsAdminController : Controller, IUpdateModel {
+
+        private readonly IOrchardServices _orchardServices;
+        private readonly ISiteService _siteService;
+
+        private const string groupInfoId = "ECommerceSiteSettings";
+
+        public ECommerceSettingsAdminController(IOrchardServices orchardServices, ISiteService siteService) {
+            _orchardServices = orchardServices;
+            _siteService = siteService;
+
+            T = NullLocalizer.Instance;
+        }
+
+        public Localizer T { get; set; }
+
+        public ActionResult Index() {
+            if (!_orchardServices.Authorizer.Authorize(CommercePermissions.ManageCommerce, null, T("Not authorized to manage e-commerce settings")))
+                return new HttpUnauthorizedResult();
+
+            var site = _siteService.GetSiteSettings();
+            dynamic model = _orchardServices.ContentManager.BuildEditor(site, groupInfoId);
+
+            if (model == null)
+                return HttpNotFound();
+
+            return View(model);
+        }
+
+        [HttpPost, ActionName("Index")]
+        public ActionResult IndexPost() {
+            if (!_orchardServices.Authorizer.Authorize(CommercePermissions.ManageCommerce, null, T("Not authorized to manage e-commerce settings")))
+                return new HttpUnauthorizedResult();
+
+            var site = _siteService.GetSiteSettings();
+            var model = _orchardServices.ContentManager.UpdateEditor(site, this, groupInfoId);
+
+            if (model == null) {
+                _orchardServices.TransactionManager.Cancel();
+                return HttpNotFound();
+            }
+
+            if (!ModelState.IsValid) {
+                _orchardServices.TransactionManager.Cancel();
+
+                return View(model);
+            }
+            _orchardServices.Notifier.Information(T("Store settings updated"));
+
+            return RedirectToAction("Index");
+        }
+
+        bool IUpdateModel.TryUpdateModel<TModel>(TModel model, string prefix, string[] includeProperties, string[] excludeProperties) {
+            return TryUpdateModel(model, prefix, includeProperties, excludeProperties);
+        }
+
+        void IUpdateModel.AddModelError(string key, LocalizedString errorMessage) {
+            ModelState.AddModelError(key, errorMessage.ToString());
+        }
+    }
+}

--- a/Drivers/AdvancedSKUProductPartDriver.cs
+++ b/Drivers/AdvancedSKUProductPartDriver.cs
@@ -40,7 +40,7 @@ namespace Nwazet.Commerce.Drivers {
                 Settings = settings,
                 SkuPattern = string.IsNullOrWhiteSpace(settings.SKUPattern) ? _SKUGenerationServices.DefaultSkuPattern : settings.SKUPattern
             };
-            if (string.IsNullOrWhiteSpace(part.Sku)) {
+            if (string.IsNullOrWhiteSpace(part.Sku) && settings.GenerateSKUAutomatically) {
                 part.Sku = _SKUGenerationServices.DefaultSkuPattern;
             }
 
@@ -53,11 +53,21 @@ namespace Nwazet.Commerce.Drivers {
 
         protected override DriverResult Editor(ProductPart part, IUpdateModel updater, dynamic shapeHelper) {
             //The part has already been updated by the default driver here
-            var model = new AdvancedSKUProductEditorViewModel();
+            var settings = _SKUGenerationServices.GetSettings();
+            var model = new AdvancedSKUProductEditorViewModel() {
+                Product = part,
+                Settings = settings,
+                SkuPattern = string.IsNullOrWhiteSpace(settings.SKUPattern) ? _SKUGenerationServices.DefaultSkuPattern : settings.SKUPattern
+            };
             if (updater.TryUpdateModel(model, Prefix, null, null)) {
                 part.Sku = model.CurrentSku;
             }
-            return Editor(part, shapeHelper);
+
+            return ContentShape("Part_Product_SKUEdit",
+                () => shapeHelper.EditorTemplate(
+                TemplateName: "Parts/AdvancedSKUProduct",
+                Model: model,
+                Prefix: Prefix));
         }
     }
 }

--- a/Drivers/AdvancedSKUProductPartDriver.cs
+++ b/Drivers/AdvancedSKUProductPartDriver.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Nwazet.Commerce.Models;
+using Nwazet.Commerce.Services;
+using Nwazet.Commerce.ViewModels;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.Drivers;
+using Orchard.Environment.Extensions;
+using Orchard.Localization;
+
+namespace Nwazet.Commerce.Drivers {
+    [OrchardFeature("Nwazet.AdvancedSKUManagement")]
+    public class AdvancedSKUProductPartDriver : ContentPartDriver<ProductPart> {
+
+        private readonly ISKUGenerationServices _SKUGenerationServices;
+
+        public AdvancedSKUProductPartDriver(ISKUGenerationServices SKUGenerationServices) {
+
+            _SKUGenerationServices = SKUGenerationServices;
+
+            T = NullLocalizer.Instance;
+        }
+
+        public Localizer T { get; set; }
+        protected override string Prefix
+        {
+            get { return "NwazetCommerceProduct"; }
+        }
+
+        protected override DriverResult Editor(ProductPart part, dynamic shapeHelper) {
+
+            var settings = _SKUGenerationServices.GetSettings();
+            var model = new AdvancedSKUProductEditorViewModel() {
+                Product = part,
+                CurrentSku = part.Sku,
+                Settings = settings,
+                SkuPattern = string.IsNullOrWhiteSpace(settings.SKUPattern) ? _SKUGenerationServices.DefaultSkuPattern : settings.SKUPattern
+            };
+            if (string.IsNullOrWhiteSpace(part.Sku)) {
+                part.Sku = _SKUGenerationServices.DefaultSkuPattern;
+            }
+
+            return ContentShape("Part_Product_SKUEdit",
+                () => shapeHelper.EditorTemplate(
+                TemplateName: "Parts/AdvancedSKUProduct",
+                Model: model, 
+                Prefix: Prefix));
+        }
+
+        protected override DriverResult Editor(ProductPart part, IUpdateModel updater, dynamic shapeHelper) {
+            //The part has already been updated by the default driver here
+            var model = new AdvancedSKUProductEditorViewModel();
+            //if (updater.TryUpdateModel(model, Prefix, null, null)) {
+            //    part.Sku = model.CurrentSku;
+            //}
+            return Editor(part, shapeHelper);
+        }
+    }
+}

--- a/Drivers/AdvancedSKUProductPartDriver.cs
+++ b/Drivers/AdvancedSKUProductPartDriver.cs
@@ -54,9 +54,9 @@ namespace Nwazet.Commerce.Drivers {
         protected override DriverResult Editor(ProductPart part, IUpdateModel updater, dynamic shapeHelper) {
             //The part has already been updated by the default driver here
             var model = new AdvancedSKUProductEditorViewModel();
-            //if (updater.TryUpdateModel(model, Prefix, null, null)) {
-            //    part.Sku = model.CurrentSku;
-            //}
+            if (updater.TryUpdateModel(model, Prefix, null, null)) {
+                part.Sku = model.CurrentSku;
+            }
             return Editor(part, shapeHelper);
         }
     }

--- a/Drivers/AdvancedSKUsSiteSettingPartDriver.cs
+++ b/Drivers/AdvancedSKUsSiteSettingPartDriver.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Nwazet.Commerce.Controllers;
+using Nwazet.Commerce.Models;
+using Nwazet.Commerce.ViewModels;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.Drivers;
+using Orchard.Environment.Extensions;
+
+namespace Nwazet.Commerce.Drivers {
+    [OrchardFeature("Nwazet.AdvancedSKUManagement")]
+    public class AdvancedSKUsSiteSettingPartDriver : ContentPartDriver<AdvancedSKUsSiteSettingPart> {
+
+        protected override string Prefix
+        {
+            get
+            {
+                return "AdvancedSKUsSiteSettings";
+            }
+        }
+
+        protected override DriverResult Editor(AdvancedSKUsSiteSettingPart part, dynamic shapeHelper) {
+            return ContentShape("SiteSettings_AdvancedSKUs",
+                    () => shapeHelper.EditorTemplate(
+                        TemplateName: "SiteSettings/AdvancedSKUs",
+                        Model: new AdancedSKUsSiteSettingsViewModel {
+                            RequireUniqueSKU = part.RequireUniqueSKU
+                        },
+                        Prefix: Prefix
+                    )
+                ).OnGroup("ECommerceSiteSettings");
+        }
+
+        protected override DriverResult Editor(AdvancedSKUsSiteSettingPart part, IUpdateModel updater, dynamic shapeHelper) {
+            var model = new AdancedSKUsSiteSettingsViewModel();
+            if (updater is ECommerceSettingsAdminController && 
+                updater.TryUpdateModel(model, Prefix, null, null)) {
+                part.RequireUniqueSKU = model.RequireUniqueSKU;
+            }
+            return Editor(part, shapeHelper);
+        }
+    }
+}

--- a/Drivers/AdvancedSKUsSiteSettingPartDriver.cs
+++ b/Drivers/AdvancedSKUsSiteSettingPartDriver.cs
@@ -28,7 +28,10 @@ namespace Nwazet.Commerce.Drivers {
                     () => shapeHelper.EditorTemplate(
                         TemplateName: "SiteSettings/AdvancedSKUs",
                         Model: new AdancedSKUsSiteSettingsViewModel {
-                            RequireUniqueSKU = part.RequireUniqueSKU
+                            RequireUniqueSKU = part.RequireUniqueSKU,
+                            GenerateSKUAutomatically = part.GenerateSKUAutomatically,
+                            SKUPattern = part.SKUPattern,
+                            AllowCustomPattern = part.AllowCustomPattern
                         },
                         Prefix: Prefix
                     )
@@ -40,6 +43,9 @@ namespace Nwazet.Commerce.Drivers {
             if (updater is ECommerceSettingsAdminController && 
                 updater.TryUpdateModel(model, Prefix, null, null)) {
                 part.RequireUniqueSKU = model.RequireUniqueSKU;
+                part.GenerateSKUAutomatically = model.GenerateSKUAutomatically;
+                part.SKUPattern = model.SKUPattern;
+                part.AllowCustomPattern = model.AllowCustomPattern;
             }
             return Editor(part, shapeHelper);
         }

--- a/Drivers/ProductPartDriver.cs
+++ b/Drivers/ProductPartDriver.cs
@@ -10,6 +10,7 @@ using Orchard.ContentManagement.Drivers;
 using Orchard.ContentManagement.Handlers;
 using Orchard.Environment.Extensions;
 using Nwazet.Commerce.ViewModels;
+using Orchard.Localization;
 
 namespace Nwazet.Commerce.Drivers {
     [OrchardFeature("Nwazet.Commerce")]
@@ -29,8 +30,11 @@ namespace Nwazet.Commerce.Drivers {
             _priceService = priceService;
             _attributeProviders = attributeProviders;
             _tieredPriceProvider = tieredPriceProvider;
+
+            T = NullLocalizer.Instance;
         }
 
+        public Localizer T { get; set; }
         protected override string Prefix {
             get { return "NwazetCommerceProduct"; }
         }

--- a/Handlers/AdvancedSKUManagementHandler.cs
+++ b/Handlers/AdvancedSKUManagementHandler.cs
@@ -75,7 +75,8 @@ namespace Nwazet.Commerce.Handlers {
         }
 
         private void ProcessSku (ProductPart part) {
-            if (string.IsNullOrWhiteSpace(part.Sku)) {
+            if (string.IsNullOrWhiteSpace(part.Sku) ||
+                _SKUGenerationServices.Value.GetSettings().AllowCustomPattern) { //AllowCustomPattern is handled inside GenerateSku
                 //generate a new sku
                 part.Sku = _SKUGenerationServices.Value.GenerateSku(part);
             }

--- a/Handlers/AdvancedSKUManagementHandler.cs
+++ b/Handlers/AdvancedSKUManagementHandler.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nwazet.Commerce.Models;
+using Nwazet.Commerce.Services;
+using Orchard;
+using Orchard.ContentManagement;
+using Orchard.ContentManagement.Handlers;
+using Orchard.Environment.Extensions;
+using Orchard.Localization;
+
+namespace Nwazet.Commerce.Handlers {
+    [OrchardFeature("Nwazet.AdvancedSKUManagement")]
+    public class AdvancedSKUManagementHandler : ContentHandler {
+
+        private readonly IOrchardServices _orchardServices;
+        private readonly IContentManager _contentManager;
+        private readonly IEnumerable<ISKUUniquenessExceptionProvider> _SKUUniquenessExceptionProviders;
+
+        public AdvancedSKUManagementHandler(
+            IOrchardServices orchardServices,
+            IContentManager contentManager,
+            IEnumerable<ISKUUniquenessExceptionProvider> SKUUniquenessExceptionProviders) {
+
+            _orchardServices = orchardServices;
+            _contentManager = contentManager;
+
+            _SKUUniquenessExceptionProviders = SKUUniquenessExceptionProviders;
+
+            T = NullLocalizer.Instance;
+        }
+
+        public Localizer T { get; set; }
+
+        protected override void UpdateEditorShape(UpdateEditorContext context) {
+            base.UpdateEditorShape(context);
+            //Apply this only for ProductParts
+            if (context.ContentItem.Parts.Any(part => part is ProductPart)) {
+                var productPart = context.ContentItem.As<ProductPart>();
+                var settings = _orchardServices.WorkContext.CurrentSite.As<AdvancedSKUsSiteSettingPart>();
+                if (settings.RequireUniqueSKU) {
+                    var sameSKUProducts = _contentManager.Query<ProductPart, ProductPartRecord>(VersionOptions.Latest)
+                        .Where(ppr => ppr.Id != productPart.Id && ppr.Sku == productPart.Sku)
+                        .List().ToList();
+                    //Handle exceptions to uniqueness of SKUs
+                    if (_SKUUniquenessExceptionProviders.Any()) {
+                        var exceptionIds = _SKUUniquenessExceptionProviders.SelectMany(provider => provider.GetIdsOfValidSKUDuplicates(productPart));
+                        sameSKUProducts = sameSKUProducts.Where(pp => !exceptionIds.Contains(pp.Id)).ToList();
+                    }
+                    if (sameSKUProducts.Any()) {
+                        context.Updater.AddModelError("", T("The SKU must be unique."));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Handlers/AdvancedSKUManagementHandler.cs
+++ b/Handlers/AdvancedSKUManagementHandler.cs
@@ -54,7 +54,7 @@ namespace Nwazet.Commerce.Handlers {
                 var settings = _orchardServices.WorkContext.CurrentSite.As<AdvancedSKUsSiteSettingPart>();
                 if (settings.RequireUniqueSKU) {
                     var sameSKUProductIds = _contentManager.Query<ProductPart, ProductPartRecord>(VersionOptions.Latest)
-                        .Where(ppr => ppr.Id != productPart.Id && ppr.Sku == productPart.Sku)
+                        .Where(ppr => ppr.Id != productPart.Record.Id && ppr.Sku == productPart.Sku)
                         .List().Select(pp => pp.Id);
                     //Handle exceptions to uniqueness of SKUs
                     if (_SKUUniquenessExceptionProviders.Any()) {

--- a/Handlers/AdvancedSKUsSiteSettingPartHandler.cs
+++ b/Handlers/AdvancedSKUsSiteSettingPartHandler.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nwazet.Commerce.Models;
+using Orchard.ContentManagement.Handlers;
+using Orchard.Environment.Extensions;
+
+namespace Nwazet.Commerce.Handlers {
+    [OrchardFeature("Nwazet.AdvancedSKUManagement")]
+    public class AdvancedSKUsSiteSettingPartHandler :ContentHandler{
+
+        public AdvancedSKUsSiteSettingPartHandler() {
+            Filters.Add(new ActivatingFilter<AdvancedSKUsSiteSettingPart>("Site"));
+        }
+    }
+}

--- a/Menus/ECommerceSettingsAdminMenu.cs
+++ b/Menus/ECommerceSettingsAdminMenu.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nwazet.Commerce.Permissions;
+using Orchard.Localization;
+using Orchard.UI.Navigation;
+
+namespace Nwazet.Commerce.Menus {
+    public class ECommerceSettingsAdminMenu : INavigationProvider {
+
+        public string MenuName
+        {
+            get { return "admin"; }
+        }
+
+        public ECommerceSettingsAdminMenu() {
+            T = NullLocalizer.Instance;
+        }
+
+        public Localizer T { get; set; }
+
+        public void GetNavigation(NavigationBuilder builder) {
+            builder
+                .AddImageSet("nwazet-commerce")
+                .Add(item => item
+                    .Caption(T("Commerce"))
+                    .Position("2")
+                    .LinkToFirstChild(false)
+
+                    .Add(subItem => subItem
+                        .Caption(T("Settings"))
+                        .Position("2.1")
+                        .Action("Index", "ECommerceSettingsAdmin", new { area = "Nwazet.Commerce" })
+                        .Permission(CommercePermissions.ManageCommerce)
+                    )
+                );
+        }
+    }
+}

--- a/Models/AdvancedSKUsSiteSettingPart.cs
+++ b/Models/AdvancedSKUsSiteSettingPart.cs
@@ -40,7 +40,7 @@ namespace Nwazet.Commerce.Models {
         /// </summary>
         public bool AllowCustomPattern
         {
-            get { return this.Retrieve(p => p.AllowCustomPattern); }
+            get { return this.Retrieve(p => p.AllowCustomPattern) && GenerateSKUAutomatically; }
             set { this.Store(p => p.AllowCustomPattern, value); }
         }
         #endregion

--- a/Models/AdvancedSKUsSiteSettingPart.cs
+++ b/Models/AdvancedSKUsSiteSettingPart.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orchard.ContentManagement;
+using Orchard.Environment.Extensions;
+
+namespace Nwazet.Commerce.Models {
+    [OrchardFeature("Nwazet.AdvancedSKUManagement")]
+    public class AdvancedSKUsSiteSettingPart : ContentPart {
+        /// <summary>
+        /// When true, upon updating a ProductPart, there is a check on the uniqueness of the SKU
+        /// </summary>
+        public bool RequireUniqueSKU
+        {
+            get { return this.Retrieve(p => p.RequireUniqueSKU); }
+            set { this.Store(p => p.RequireUniqueSKU, value); }
+        }
+        /// <summary>
+        /// When true, SKUs are generated automatically for ProductParts
+        /// </summary>
+        public bool GenerateSKUAutomatically
+        {
+            get { return this.Retrieve(p => p.GenerateSKUAutomatically); }
+            set { this.Store(p => p.GenerateSKUAutomatically, value); }
+        }
+        /// <summary>
+        /// When true, if GenerateSKUAutomatically == true, prevents the SKU from being editable in the backend.
+        /// </summary>
+        public bool DisableSKUEditing
+        {
+            get { return this.Retrieve(p => p.DisableSKUEditing); }
+            set { this.Store(p => p.DisableSKUEditing, value); }
+        }
+        /// <summary>
+        /// When true, prevents changes to a ProductPart's SKU after publishing
+        /// </summary>
+        public bool DisableSKUUpdate
+        {
+            get { return this.Retrieve(p => p.DisableSKUEditing); }
+            set { this.Store(p => p.DisableSKUEditing, value); }
+        }
+    }
+}

--- a/Models/AdvancedSKUsSiteSettingPart.cs
+++ b/Models/AdvancedSKUsSiteSettingPart.cs
@@ -18,28 +18,31 @@ namespace Nwazet.Commerce.Models {
             set { this.Store(p => p.RequireUniqueSKU, value); }
         }
         /// <summary>
-        /// When true, SKUs are generated automatically for ProductParts
+        /// When true, SKUs are generated automatically for ProductParts, using a systme that is similar to AutoRoute
         /// </summary>
         public bool GenerateSKUAutomatically
         {
             get { return this.Retrieve(p => p.GenerateSKUAutomatically); }
             set { this.Store(p => p.GenerateSKUAutomatically, value); }
         }
+
+        #region Settings for AutoSKU
         /// <summary>
-        /// When true, if GenerateSKUAutomatically == true, prevents the SKU from being editable in the backend.
+        /// The pattern used in SKU generation
         /// </summary>
-        public bool DisableSKUEditing
+        public string SKUPattern
         {
-            get { return this.Retrieve(p => p.DisableSKUEditing); }
-            set { this.Store(p => p.DisableSKUEditing, value); }
+            get { return this.Retrieve(p => p.SKUPattern); }
+            set { this.Store(p=>p.SKUPattern, value); }
         }
         /// <summary>
-        /// When true, prevents changes to a ProductPart's SKU after publishing
+        /// Allow the user to change the pattern on each item
         /// </summary>
-        public bool DisableSKUUpdate
+        public bool AllowCustomPattern
         {
-            get { return this.Retrieve(p => p.DisableSKUEditing); }
-            set { this.Store(p => p.DisableSKUEditing, value); }
+            get { return this.Retrieve(p => p.AllowCustomPattern); }
+            set { this.Store(p => p.AllowCustomPattern, value); }
         }
+        #endregion
     }
 }

--- a/Module.txt
+++ b/Module.txt
@@ -71,3 +71,8 @@ Features:
         Description: Collect additional information when specific product attributes are selected
         Category: Commerce
         Dependencies: Nwazet.Commerce, Nwazet.Attributes
+	Nwazet.AdvancedSKUManagement:
+		Name: Nwazet Advanced SKU Management
+        Description: Makes the use of SKUs more advanced, by providing options related to their uniqueness and automatic generation
+        Category: Commerce
+        Dependencies: Nwazet.Commerce

--- a/Nwazet.Commerce.csproj
+++ b/Nwazet.Commerce.csproj
@@ -320,6 +320,7 @@
     <Compile Include="Routes\StripeRoutes.cs" />
     <Compile Include="Routes\OrderRoutes.cs" />
     <Compile Include="Routes\CommerceRoutes.cs" />
+    <Compile Include="Services\ISKUGenerationServices.cs" />
     <Compile Include="Services\ISKUUniquenessExceptionProvider.cs" />
     <Compile Include="Services\LocalizationSKUUniquenessExceptionProvider.cs" />
     <Compile Include="Services\ProductResolverSelector.cs" />
@@ -339,6 +340,7 @@
     <Compile Include="Services\ProductAttributeService.cs" />
     <Compile Include="Services\ProductDiscountPriceProvider.cs" />
     <Compile Include="Services\ShippingService.cs" />
+    <Compile Include="Services\SKUGenerationServices.cs" />
     <Compile Include="Services\TextProductAttributeExtensionProvider.cs" />
     <Compile Include="Services\ZipCodeTaxProvider.cs" />
     <Compile Include="Services\StateOrCountryTaxProvider.cs" />

--- a/Nwazet.Commerce.csproj
+++ b/Nwazet.Commerce.csproj
@@ -72,6 +72,10 @@
       <Project>{2D1D92BB-4555-4CBE-8D0E-63563D6CE4C6}</Project> 
       <Name>Orchard.Framework</Name> 
     </ProjectReference> 
+    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Localization\Orchard.Localization.csproj"> 
+      <Project>{fbc8b571-ed50-49d8-8d9d-64ab7454a0d6}</Project> 
+      <Name>Orchard.Localization</Name> 
+    </ProjectReference> 
     <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.MediaLibrary\Orchard.MediaLibrary.csproj"> 
       <Project>{73a7688a-5bd3-4f7e-adfa-ce36c5a10e3b}</Project> 
       <Name>Orchard.MediaLibrary</Name> 
@@ -193,6 +197,7 @@
   <ItemGroup> 
     <Compile Include="Activities\CommerceActivity.cs" /> 
     <Compile Include="Activities\OrderActivity.cs" /> 
+    <Compile Include="Controllers\ECommerceSettingsAdminController .cs" /> 
     <Compile Include="Controllers\ProductSettingsAdminController.cs" /> 
     <Compile Include="Controllers\BundleAdminController.cs" /> 
     <Compile Include="Controllers\AttributesAdminController.cs" /> 
@@ -206,6 +211,8 @@
     <Compile Include="Controllers\ShippingAdminController.cs" /> 
     <Compile Include="Controllers\ShoppingCartController.cs" /> 
     <Compile Include="Controllers\StripeController.cs" /> 
+    <Compile Include="Drivers\AdvancedSKUProductPartDriver.cs" /> 
+    <Compile Include="Drivers\AdvancedSKUsSiteSettingPartDriver.cs" /> 
     <Compile Include="Drivers\BundlePartDriver.cs" /> 
     <Compile Include="Drivers\OrderPartDriver.cs" /> 
     <Compile Include="Drivers\ProductSettingsPartDriver.cs" /> 
@@ -223,6 +230,8 @@
     <Compile Include="Drivers\WeightBasedShippingMethodPartDriver.cs" /> 
     <Compile Include="Exceptions\StripeException.cs" /> 
     <Compile Include="Filters\ReferrerFilter.cs" /> 
+    <Compile Include="Handlers\AdvancedSKUManagementHandler.cs" /> 
+    <Compile Include="Handlers\AdvancedSKUsSiteSettingPartHandler.cs" /> 
     <Compile Include="Handlers\BundlePartHandler.cs" /> 
     <Compile Include="Handlers\AttributePartHandler.cs" /> 
     <Compile Include="Handlers\AttributesPartHandler.cs" /> 
@@ -236,6 +245,7 @@
     <Compile Include="Handlers\SizeBasedShippingMethodPartHandler.cs" /> 
     <Compile Include="Handlers\WeightBasedShippingMethodPartHandler.cs" /> 
     <Compile Include="Handlers\ProductPartHandler.cs" /> 
+    <Compile Include="Menus\ECommerceSettingsAdminMenu.cs" /> 
     <Compile Include="Menus\ReportsAdminMenu.cs" /> 
     <Compile Include="Menus\ProductSettingsAdminMenu.cs" /> 
     <Compile Include="Menus\AttributeAdminMenu.cs" /> 
@@ -253,6 +263,7 @@
     <Compile Include="Migrations\DiscountMigrations.cs" /> 
     <Compile Include="Migrations\ShippingMigrations.cs" /> 
     <Compile Include="Models\Address.cs" /> 
+    <Compile Include="Models\AdvancedSKUsSiteSettingPart.cs" /> 
     <Compile Include="Models\CheckoutError.cs" /> 
     <Compile Include="Models\CheckoutItem.cs" /> 
     <Compile Include="Models\ConversionUtilities.cs" /> 
@@ -320,6 +331,9 @@
     <Compile Include="Routes\StripeRoutes.cs" /> 
     <Compile Include="Routes\OrderRoutes.cs" /> 
     <Compile Include="Routes\CommerceRoutes.cs" /> 
+    <Compile Include="Services\ISKUGenerationServices.cs" /> 
+    <Compile Include="Services\ISKUUniquenessExceptionProvider.cs" /> 
+    <Compile Include="Services\LocalizationSKUUniquenessExceptionProvider.cs" /> 
     <Compile Include="Services\ProductResolverSelector.cs" /> 
     <Compile Include="Services\AddressFormatter.cs" /> 
     <Compile Include="Services\BundleService.cs" /> 
@@ -337,6 +351,7 @@
     <Compile Include="Services\ProductAttributeService.cs" /> 
     <Compile Include="Services\ProductDiscountPriceProvider.cs" /> 
     <Compile Include="Services\ShippingService.cs" /> 
+    <Compile Include="Services\SKUGenerationServices.cs" /> 
     <Compile Include="Services\TextProductAttributeExtensionProvider.cs" /> 
     <Compile Include="Services\ZipCodeTaxProvider.cs" /> 
     <Compile Include="Services\StateOrCountryTaxProvider.cs" /> 
@@ -371,6 +386,8 @@
     <Compile Include="Tokens\CartTokens.cs" /> 
     <Compile Include="Tokens\OrderTokens.cs" /> 
     <Compile Include="Tokens\ProductTokens.cs" /> 
+    <Compile Include="ViewModels\AdancedSKUsSiteSettingsViewModel.cs" /> 
+    <Compile Include="ViewModels\AdvancedSKUProductEditorViewModel.cs" /> 
     <Compile Include="ViewModels\ProductAttributePartDisplayViewModel.cs" /> 
     <Compile Include="ViewModels\ProductAttributePartEditViewModel.cs" /> 
     <Compile Include="ViewModels\AttributesIndexViewModel.cs" /> 
@@ -489,6 +506,9 @@
   <ItemGroup> 
     <None Include="app.config" /> 
     <None Include="packages.config" /> 
+    <None Include="Views\ECommerceSettingsAdmin\Index.cshtml" /> 
+    <None Include="Views\EditorTemplates\Parts\AdvancedSKUProduct.cshtml" /> 
+    <None Include="Views\EditorTemplates\SiteSettings\AdvancedSKUs.cshtml" /> 
   </ItemGroup> 
   <PropertyGroup> 
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion> 

--- a/Nwazet.Commerce.csproj
+++ b/Nwazet.Commerce.csproj
@@ -1,524 +1,529 @@
-﻿<?xml version="1.0" encoding="utf-8"?> 
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" /> 
-  <PropertyGroup> 
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration> 
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform> 
-    <ProductVersion>9.0.30729</ProductVersion> 
-    <SchemaVersion>2.0</SchemaVersion> 
-    <ProjectGuid>{909ACC2C-D672-4752-B75B-6822E05FE0E3}</ProjectGuid> 
-    <ProjectTypeGuids>{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids> 
-    <OutputType>Library</OutputType> 
-    <AppDesignerFolder>Properties</AppDesignerFolder> 
-    <RootNamespace>Nwazet.Commerce</RootNamespace> 
-    <AssemblyName>Nwazet.Commerce</AssemblyName> 
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion> 
-    <MvcBuildViews>false</MvcBuildViews> 
-    <FileUpgradeFlags> 
-    </FileUpgradeFlags> 
-    <OldToolsVersion>4.0</OldToolsVersion> 
-    <UpgradeBackupLocation> 
-    </UpgradeBackupLocation> 
-    <TargetFrameworkProfile /> 
-    <NuGetPackageImportStamp> 
-    </NuGetPackageImportStamp> 
-  </PropertyGroup> 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "> 
-    <DebugSymbols>true</DebugSymbols> 
-    <DebugType>full</DebugType> 
-    <Optimize>false</Optimize> 
-    <OutputPath>bin\</OutputPath> 
-    <DefineConstants>DEBUG;TRACE</DefineConstants> 
-    <ErrorReport>prompt</ErrorReport> 
-    <WarningLevel>4</WarningLevel> 
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet> 
-    <Prefer32Bit>false</Prefer32Bit> 
-    <LangVersion>6</LangVersion> 
-  </PropertyGroup> 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "> 
-    <DebugType>full</DebugType> 
-    <Optimize>false</Optimize> 
-    <OutputPath>bin\</OutputPath> 
-    <DefineConstants>TRACE</DefineConstants> 
-    <ErrorReport>prompt</ErrorReport> 
-    <WarningLevel>4</WarningLevel> 
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet> 
-    <Prefer32Bit>false</Prefer32Bit> 
-    <DebugSymbols>true</DebugSymbols> 
-  </PropertyGroup> 
-  <ItemGroup> 
-    <Reference Include="Microsoft.CSharp" /> 
-    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
-      <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath> 
-      <Private>True</Private> 
-    </Reference> 
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL"> 
-      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath> 
-      <Private>True</Private> 
-    </Reference> 
-    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Autoroute\Orchard.Autoroute.csproj"> 
-      <Project>{66fccd76-2761-47e3-8d11-b45d0001ddaa}</Project> 
-      <Name>Orchard.Autoroute</Name> 
-    </ProjectReference> 
-    <ProjectReference Include="..\..\..\Orchard.Web\Core\Orchard.Core.csproj"> 
-      <Project>{9916839C-39FC-4CEB-A5AF-89CA7E87119F}</Project> 
-      <Name>Orchard.Core</Name> 
-    </ProjectReference> 
-    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Fields\Orchard.Fields.csproj"> 
-      <Project>{3787dde5-e5c8-4841-bda7-dcb325388064}</Project> 
-      <Name>Orchard.Fields</Name> 
-    </ProjectReference> 
-    <ProjectReference Include="..\..\..\Orchard\Orchard.Framework.csproj"> 
-      <Project>{2D1D92BB-4555-4CBE-8D0E-63563D6CE4C6}</Project> 
-      <Name>Orchard.Framework</Name> 
-    </ProjectReference> 
-    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.MediaLibrary\Orchard.MediaLibrary.csproj"> 
-      <Project>{73a7688a-5bd3-4f7e-adfa-ce36c5a10e3b}</Project> 
-      <Name>Orchard.MediaLibrary</Name> 
-    </ProjectReference> 
-    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Roles\Orchard.Roles.csproj"> 
-      <Project>{d10ad48f-407d-4db5-a328-173ec7cb010f}</Project> 
-      <Name>Orchard.Roles</Name> 
-    </ProjectReference> 
-    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.SecureSocketsLayer\Orchard.SecureSocketsLayer.csproj"> 
-      <Project>{36b82383-d69e-4897-a24a-648babdf80ec}</Project> 
-      <Name>Orchard.SecureSocketsLayer</Name> 
-    </ProjectReference> 
-    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Tokens\Orchard.Tokens.csproj"> 
-      <Project>{6f759635-13d7-4e94-bcc9-80445d63f117}</Project> 
-      <Name>Orchard.Tokens</Name> 
-    </ProjectReference> 
-    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Workflows\Orchard.Workflows.csproj"> 
-      <Project>{7059493c-8251-4764-9c1e-2368b8b485bc}</Project> 
-      <Name>Orchard.Workflows</Name> 
-    </ProjectReference> 
-    <Reference Include="System" /> 
-    <Reference Include="System.Data" /> 
-    <Reference Include="System.ComponentModel.DataAnnotations"> 
-      <RequiredTargetFramework>3.5</RequiredTargetFramework> 
-    </Reference> 
-    <Reference Include="System.Web" /> 
-    <Reference Include="System.Web.Abstractions" /> 
-    <Reference Include="System.Web.DynamicData" /> 
-    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
-      <SpecificVersion>False</SpecificVersion> 
-      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath> 
-    </Reference> 
-    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
-      <HintPath>..\..\..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath> 
-      <Private>True</Private> 
-    </Reference> 
-    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
-      <SpecificVersion>False</SpecificVersion> 
-      <HintPath>..\..\..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath> 
-    </Reference> 
-    <Reference Include="System.Web.Routing" /> 
-    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
-      <SpecificVersion>False</SpecificVersion> 
-      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath> 
-    </Reference> 
-    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
-      <SpecificVersion>False</SpecificVersion> 
-      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath> 
-    </Reference> 
-    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
-      <SpecificVersion>False</SpecificVersion> 
-      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath> 
-    </Reference> 
-    <Reference Include="System.Xml" /> 
-    <Reference Include="System.Configuration" /> 
-    <Reference Include="System.Xml.Linq" /> 
-  </ItemGroup> 
-  <ItemGroup> 
-    <Content Include="Content\accepted-cards.png" /> 
-    <Content Include="Content\checkout-with-stripe.png" /> 
-    <Content Include="Content\menu.nwazet-commerce.png" /> 
-    <Content Include="Content\move.gif" /> 
-    <Content Include="LICENSE.txt" /> 
-    <Content Include="Scripts\attribute-admin.js" /> 
-    <Content Include="Scripts\chartjs.js" /> 
-    <Content Include="Scripts\chartjs.min.js"> 
-      <DependentUpon>chartjs.js</DependentUpon> 
-    </Content> 
-    <Content Include="Scripts\inventory.js" /> 
-    <Content Include="Scripts\inventory.min.js"> 
-      <DependentUpon>inventory.js</DependentUpon> 
-    </Content> 
-    <Content Include="Scripts\jquery.iframe-transport.js" /> 
-    <Content Include="Scripts\mustache.js" /> 
-    <Content Include="Scripts\order-admin.js" /> 
-    <Content Include="Scripts\order-admin.min.js"> 
-      <DependentUpon>order-admin.js</DependentUpon> 
-    </Content> 
-    <Content Include="Scripts\referral.js" /> 
-    <Content Include="Scripts\referral.min.js"> 
-      <DependentUpon>referral.js</DependentUpon> 
-    </Content> 
-    <Content Include="Scripts\attribute-extensions.js" /> 
-    <Content Include="Scripts\report.js" /> 
-    <Content Include="Scripts\report.min.js"> 
-      <DependentUpon>report.js</DependentUpon> 
-    </Content> 
-    <Content Include="Scripts\ship.js" /> 
-    <Content Include="Scripts\ship.min.js"> 
-      <DependentUpon>ship.js</DependentUpon> 
-    </Content> 
-    <Content Include="Scripts\shoppingcart.js"> 
-      <LastGenOutput>shoppingcart.min.js</LastGenOutput> 
-    </Content> 
-    <Content Include="Scripts\shoppingcart.min.js"> 
-      <DependentUpon>shoppingcart.js</DependentUpon> 
-    </Content> 
-    <Content Include="Styles\bundle.nwazet-commerce-admin.css" /> 
-    <Content Include="Styles\attribute.nwazet-commerce-admin.css" /> 
-    <Content Include="Styles\reports-admin.css" /> 
-    <Content Include="Styles\workflows-activity-order-status-changed-product.css" /> 
-    <Content Include="Styles\workflows-activity-order-tracking-url-changed.css" /> 
-    <Content Include="Styles\workflows-activity-new-order.css" /> 
-    <Content Include="Styles\workflows-activity-order-status-changed.css" /> 
-    <Content Include="Styles\discount.nwazet-commerce-admin.css" /> 
-    <Content Include="Styles\menu.nwazet-commerce-admin.css" /> 
-    <Content Include="Styles\workflows-activity-cart-updated.css" /> 
-    <Content Include="Styles\order-admin.css"> 
-      <DependentUpon>order-admin.less</DependentUpon> 
-    </Content> 
-    <Content Include="Styles\order-admin.min.css"> 
-      <DependentUpon>order-admin.less</DependentUpon> 
-    </Content> 
-    <Content Include="Web.config" /> 
-    <Content Include="Scripts\Web.config" /> 
-    <Content Include="Properties\AssemblyInfo.cs" /> 
-    <Content Include="Module.txt" /> 
-  </ItemGroup> 
-  <ItemGroup> 
-    <Compile Include="Activities\CommerceActivity.cs" /> 
-    <Compile Include="Activities\OrderActivity.cs" /> 
-    <Compile Include="Controllers\ProductSettingsAdminController.cs" /> 
-    <Compile Include="Controllers\BundleAdminController.cs" /> 
-    <Compile Include="Controllers\AttributesAdminController.cs" /> 
-    <Compile Include="Controllers\OrderAdminController.cs" /> 
-    <Compile Include="Controllers\OrderSslController.cs" /> 
-    <Compile Include="Controllers\ReportController.cs" /> 
-    <Compile Include="Controllers\TaxAdminController.cs" /> 
-    <Compile Include="Controllers\UspsAdminController.cs" /> 
-    <Compile Include="Controllers\PromotionAdminController.cs" /> 
-    <Compile Include="Controllers\ProductAdminController.cs" /> 
-    <Compile Include="Controllers\ShippingAdminController.cs" /> 
-    <Compile Include="Controllers\ShoppingCartController.cs" /> 
-    <Compile Include="Controllers\StripeController.cs" /> 
-    <Compile Include="Drivers\BundlePartDriver.cs" /> 
-    <Compile Include="Drivers\OrderPartDriver.cs" /> 
-    <Compile Include="Drivers\ProductSettingsPartDriver.cs" /> 
-    <Compile Include="Drivers\ZipCodeTaxPartDriver.cs" /> 
-    <Compile Include="Drivers\StateOrCountryTaxPartDriver.cs" /> 
-    <Compile Include="Drivers\UspsShippingMethodPartDriver.cs" /> 
-    <Compile Include="Drivers\UspsSettingsPartDriver.cs" /> 
-    <Compile Include="Drivers\StripeSettingsPartDriver.cs" /> 
-    <Compile Include="Drivers\ProductAttributesPartDriver.cs" /> 
-    <Compile Include="Drivers\ProductAttributePartDriver.cs" /> 
-    <Compile Include="Drivers\DiscountPartDriver.cs" /> 
-    <Compile Include="Drivers\SizeBasedShippingMethodPartDriver.cs" /> 
-    <Compile Include="Drivers\ProductPartDriver.cs" /> 
-    <Compile Include="Drivers\ShoppingCartWidgetDriver.cs" /> 
-    <Compile Include="Drivers\WeightBasedShippingMethodPartDriver.cs" /> 
-    <Compile Include="Exceptions\StripeException.cs" /> 
-    <Compile Include="Filters\ReferrerFilter.cs" /> 
-    <Compile Include="Handlers\BundlePartHandler.cs" /> 
-    <Compile Include="Handlers\AttributePartHandler.cs" /> 
-    <Compile Include="Handlers\AttributesPartHandler.cs" /> 
-    <Compile Include="Handlers\OrderPartHandler.cs" /> 
-    <Compile Include="Handlers\ProductSettingsPartHandler.cs" /> 
-    <Compile Include="Handlers\StateOrCountryTaxPartHandler.cs" /> 
-    <Compile Include="Handlers\UspsShippingMethodPartHandler.cs" /> 
-    <Compile Include="Handlers\UspsSettingsPartHandler.cs" /> 
-    <Compile Include="Handlers\StripeSettingsPartHandler.cs" /> 
-    <Compile Include="Handlers\DiscountPartHandler.cs" /> 
-    <Compile Include="Handlers\SizeBasedShippingMethodPartHandler.cs" /> 
-    <Compile Include="Handlers\WeightBasedShippingMethodPartHandler.cs" /> 
-    <Compile Include="Handlers\ProductPartHandler.cs" /> 
-    <Compile Include="Menus\ReportsAdminMenu.cs" /> 
-    <Compile Include="Menus\ProductSettingsAdminMenu.cs" /> 
-    <Compile Include="Menus\AttributeAdminMenu.cs" /> 
-    <Compile Include="Menus\OrderAdminMenu.cs" /> 
-    <Compile Include="Menus\TaxAdminMenu.cs" /> 
-    <Compile Include="Menus\PromotionAdminMenu.cs" /> 
-    <Compile Include="Menus\ProductAdminMenu.cs" /> 
-    <Compile Include="Menus\ShippingAdminMenu.cs" /> 
-    <Compile Include="Migrations\BundleMigrations.cs" /> 
-    <Compile Include="Migrations\CommerceMigrations.cs" /> 
-    <Compile Include="Migrations\AttributesMigrations.cs" /> 
-    <Compile Include="Migrations\OrderMigrations.cs" /> 
-    <Compile Include="Migrations\TaxMigrations.cs" /> 
-    <Compile Include="Migrations\UspsMigrations.cs" /> 
-    <Compile Include="Migrations\DiscountMigrations.cs" /> 
-    <Compile Include="Migrations\ShippingMigrations.cs" /> 
-    <Compile Include="Models\Address.cs" /> 
-    <Compile Include="Models\CheckoutError.cs" /> 
-    <Compile Include="Models\CheckoutItem.cs" /> 
-    <Compile Include="Models\ConversionUtilities.cs" /> 
-    <Compile Include="Models\Charge.cs" /> 
-    <Compile Include="Models\ICharge.cs" /> 
-    <Compile Include="Models\OrderEvent.cs" /> 
-    <Compile Include="Models\OrderPart.cs" /> 
-    <Compile Include="Models\OrderPartRecord.cs" /> 
-    <Compile Include="Models\PriceTier.cs" /> 
-    <Compile Include="Models\ProductAttributeValue.cs" /> 
-    <Compile Include="Models\ProductAttributeValueExtended.cs" /> 
-    <Compile Include="Models\ProductSettingsPart.cs" /> 
-    <Compile Include="Models\Reporting\ChartType.cs" /> 
-    <Compile Include="Models\Reporting\ICommerceReport.cs" /> 
-    <Compile Include="Models\Reporting\ReportData.cs" /> 
-    <Compile Include="Models\Reporting\ReportDataPoint.cs" /> 
-    <Compile Include="Models\Reporting\TimePeriod.cs" /> 
-    <Compile Include="Models\ZipCodeTaxPart.cs" /> 
-    <Compile Include="Models\StateOrCountryTaxPart.cs" /> 
-    <Compile Include="Models\StateOrCountryTaxPartRecord.cs" /> 
-    <Compile Include="Models\CreditCardCharge.cs" /> 
-    <Compile Include="Models\TaxAmount.cs" /> 
-    <Compile Include="Models\ShippingException.cs" /> 
-    <Compile Include="Models\UspsShippingMethodPartRecord.cs" /> 
-    <Compile Include="Models\UspsSettingsPart.cs" /> 
-    <Compile Include="Models\ShippingOption.cs" /> 
-    <Compile Include="Models\UspsShippingOptionList.cs" /> 
-    <Compile Include="Models\UspsShippingMethodPart.cs" /> 
-    <Compile Include="Models\StripeSettingsPart.cs" /> 
-    <Compile Include="Models\ProductAttributesPart.cs" /> 
-    <Compile Include="Models\ProductAttributesPartRecord.cs" /> 
-    <Compile Include="Models\ProductAttributePart.cs" /> 
-    <Compile Include="Models\ProductAttributePartRecord.cs" /> 
-    <Compile Include="Models\BundlePart.cs" /> 
-    <Compile Include="Models\BundlePartRecord.cs" /> 
-    <Compile Include="Models\BundleProductsRecord.cs" /> 
-    <Compile Include="Models\DiscountPart.cs" /> 
-    <Compile Include="Models\DiscountPartRecord.cs" /> 
-    <Compile Include="Models\SizeBasedShippingMethodPart.cs" /> 
-    <Compile Include="Models\SizeBasedShippingMethodPartRecord.cs" /> 
-    <Compile Include="Models\ProductPartQuantity.cs" /> 
-    <Compile Include="Models\ProductQuantity.cs" /> 
-    <Compile Include="Models\WeightBasedShippingMethodPart.cs" /> 
-    <Compile Include="Models\WeightBasedShippingMethodPartRecord.cs" /> 
-    <Compile Include="Models\IProduct.cs" /> 
-    <Compile Include="Models\IShoppingCart.cs" /> 
-    <Compile Include="Models\ProductPart.cs" /> 
-    <Compile Include="Models\ProductPartRecord.cs" /> 
-    <Compile Include="Models\ShippingArea.cs" /> 
-    <Compile Include="Models\ShoppingCart.cs" /> 
-    <Compile Include="Models\ShoppingCartItem.cs" /> 
-    <Compile Include="Models\ShoppingCartQuantityProduct.cs" /> 
-    <Compile Include="Models\ShoppingCartWidgetPart.cs" /> 
-    <Compile Include="Permissions\CommercePermissions.cs" /> 
-    <Compile Include="Permissions\ReportPermissions.cs" /> 
-    <Compile Include="Permissions\OrderPermissions.cs" /> 
-    <Compile Include="Reports\AverageSaleAmountReport.cs" /> 
-    <Compile Include="Reports\BaseSalesReport.cs" /> 
-    <Compile Include="Reports\SalesByBestSellingProductsReport.cs" /> 
-    <Compile Include="Reports\MostProfitableProductsReport.cs" /> 
-    <Compile Include="Reports\BestSellingProductsReport.cs" /> 
-    <Compile Include="Reports\TotalSalesReport.cs" /> 
-    <Compile Include="Reports\NumberOfSalesReport.cs" /> 
-    <Compile Include="Routes\UspsRoutes.cs" /> 
-    <Compile Include="Routes\StripeRoutes.cs" /> 
-    <Compile Include="Routes\OrderRoutes.cs" /> 
-    <Compile Include="Routes\CommerceRoutes.cs" /> 
-    <Compile Include="Services\ProductResolverSelector.cs" /> 
-    <Compile Include="Services\AddressFormatter.cs" /> 
-    <Compile Include="Services\BundleService.cs" /> 
-    <Compile Include="Services\Country.cs" /> 
-    <Compile Include="Services\IProductAttributeExtensionProvider.cs" /> 
-    <Compile Include="Services\IOrderService.cs" /> 
-    <Compile Include="Services\IProductAttributeService.cs" /> 
-    <Compile Include="Services\IStripeWebService.cs" /> 
-    <Compile Include="Services\ITax.cs" /> 
-    <Compile Include="Services\ITaxProvider.cs" /> 
-    <Compile Include="Services\ITieredPriceProvider.cs" /> 
-    <Compile Include="Services\IUspsService.cs" /> 
-    <Compile Include="Services\IUspsWebService.cs" /> 
-    <Compile Include="Services\OrderService.cs" /> 
-    <Compile Include="Services\ProductAttributeService.cs" /> 
-    <Compile Include="Services\ProductDiscountPriceProvider.cs" /> 
-    <Compile Include="Services\ShippingService.cs" /> 
-    <Compile Include="Services\TextProductAttributeExtensionProvider.cs" /> 
-    <Compile Include="Services\ZipCodeTaxProvider.cs" /> 
-    <Compile Include="Services\StateOrCountryTaxProvider.cs" /> 
-    <Compile Include="Services\StripeWebService.cs" /> 
-    <Compile Include="Services\TieredPriceProvider.cs" /> 
-    <Compile Include="Services\UspsContainer.cs" /> 
-    <Compile Include="Services\UspsService.cs" /> 
-    <Compile Include="Services\UspsShippingMethodProvider.cs" /> 
-    <Compile Include="Services\IAddressFormatter.cs" /> 
-    <Compile Include="Services\StripeService.cs" /> 
-    <Compile Include="Services\IStripeService.cs" /> 
-    <Compile Include="Services\Discount.cs" /> 
-    <Compile Include="Services\DiscountPriceProvider.cs" /> 
-    <Compile Include="Services\IProductAttributesDriver.cs" /> 
-    <Compile Include="Services\IPriceProvider.cs" /> 
-    <Compile Include="Services\IPriceService.cs" /> 
-    <Compile Include="Services\IPromotion.cs" /> 
-    <Compile Include="Services\IShoppingCartStorage.cs" /> 
-    <Compile Include="Services\PriceService.cs" /> 
-    <Compile Include="Services\ShoppingCartSessionStorage.cs" /> 
-    <Compile Include="Services\SizeBasedShippingMethodProvider.cs" /> 
-    <Compile Include="Services\CoreShippingAreas.cs" /> 
-    <Compile Include="Services\IExtraCartInfoProvider.cs" /> 
-    <Compile Include="Services\IShippingMethodProvider.cs" /> 
-    <Compile Include="Services\ReferrerCartInfoProvider.cs" /> 
-    <Compile Include="Services\ICheckoutService.cs" /> 
-    <Compile Include="Services\IShippingAreaProvider.cs" /> 
-    <Compile Include="Services\IShippingMethod.cs" /> 
-    <Compile Include="Services\UspsWebService.cs" /> 
-    <Compile Include="Services\WeightBasedShippingMethodProvider.cs" /> 
-    <Compile Include="Services\UnitedStates.cs" /> 
-    <Compile Include="Tokens\CartTokens.cs" /> 
-    <Compile Include="Tokens\OrderTokens.cs" /> 
-    <Compile Include="Tokens\ProductTokens.cs" /> 
-    <Compile Include="ViewModels\ProductAttributePartDisplayViewModel.cs" /> 
-    <Compile Include="ViewModels\ProductAttributePartEditViewModel.cs" /> 
-    <Compile Include="ViewModels\AttributesIndexViewModel.cs" /> 
-    <Compile Include="ViewModels\BundleViewModel.cs" /> 
-    <Compile Include="ViewModels\ListOrdersViewModel.cs" /> 
-    <Compile Include="ViewModels\OrderEditorViewModel.cs" /> 
-    <Compile Include="ViewModels\PricingSettingsViewModel.cs" /> 
-    <Compile Include="ViewModels\ProductEditorViewModel.cs" /> 
-    <Compile Include="ViewModels\ReportDataViewModel.cs" /> 
-    <Compile Include="ViewModels\TaxIndexViewModel.cs" /> 
-    <Compile Include="ViewModels\DiscountEditorViewModel.cs" /> 
-    <Compile Include="ViewModels\ProductAttributesPartEditViewModel.cs" /> 
-    <Compile Include="ViewModels\PromotionIndexViewModel.cs" /> 
-    <Compile Include="ViewModels\ShippingMethodIndexViewModel.cs" /> 
-    <Compile Include="ViewModels\StripeCheckoutViewModel.cs" /> 
-    <Compile Include="ViewModels\UpdateShoppingCartItemViewModel.cs" /> 
-  </ItemGroup> 
-  <ItemGroup> 
-    <Content Include="Content\Web.config" /> 
-    <Content Include="placement.info"> 
-      <SubType>Designer</SubType> 
-    </Content> 
-    <Content Include="Views\EditorTemplates\Parts\GoogleCheckoutSettings.cshtml" /> 
-    <Content Include="Views\EditorTemplates\Parts\Product.cshtml" /> 
-    <Content Include="Views\Parts\Product.cshtml" /> 
-  </ItemGroup> 
-  <ItemGroup> 
-    <Content Include="Styles\Web.config" /> 
-    <Content Include="Views\ShippingAdmin\Index.cshtml" /> 
-    <Content Include="Views\EditorTemplates\Parts\WeightBasedShippingMethod.cshtml" /> 
-    <Content Include="Views\ProductAdmin\List.cshtml" /> 
-    <Content Include="Views\Parts\Bundle.cshtml" /> 
-    <Content Include="Views\EditorTemplates\Parts\Bundle.cshtml" /> 
-    <Content Include="Views\ProductSummaryAdmin.cshtml" /> 
-    <Content Include="Views\BundleSummaryAdmin.cshtml" /> 
-    <Content Include="Views\EditorTemplates\Parts\SizeBasedShippingMethod.cshtml" /> 
-    <Content Include="Views\EditorTemplates\Parts\Discount.cshtml" /> 
-    <Content Include="Views\Price.cshtml" /> 
-    <Content Include="Views\PromotionAdmin\Index.cshtml" /> 
-    <Content Include="Views\ShoppingCart.Summary.cshtml" /> 
-    <Content Include="Views\Parts\Product.AddButton.cshtml" /> 
-    <Content Include="Views\ShoppingCart.cshtml" /> 
-    <Content Include="Views\ShoppingCartWidget.cshtml" /> 
-    <Content Include="Views\TitleWithLink.cshtml" /> 
-  </ItemGroup> 
-  <ItemGroup> 
-    <Content Include="Scripts\inventory.min.js.map"> 
-      <DependentUpon>inventory.js</DependentUpon> 
-    </Content> 
-    <Content Include="Scripts\referral.min.js.map"> 
-      <DependentUpon>referral.js</DependentUpon> 
-    </Content> 
-    <Content Include="Scripts\shoppingcart.min.js.map"> 
-      <DependentUpon>shoppingcart.js</DependentUpon> 
-    </Content> 
-    <Content Include="Views\AttributesAdmin\Index.cshtml" /> 
-    <Content Include="Views\EditorTemplates\Parts\ProductAttribute.cshtml" /> 
-    <Content Include="Views\EditorTemplates\Parts\ProductAttributes.cshtml" /> 
-    <Content Include="Views\Stripe.cshtml" /> 
-    <Content Include="Views\EditorTemplates\Parts\StripeSettings.cshtml" /> 
-    <Content Include="Views\EditorTemplates\Parts\UspsShippingMethod.cshtml" /> 
-    <Content Include="Views\EditorTemplates\Parts\UspsSettings.cshtml" /> 
-    <Content Include="Views\Parts\ProductAttributes.cshtml" /> 
-    <Content Include="Views\ShippingInfoForm.cshtml" /> 
-    <Content Include="Views\ShippingOptions.cshtml" /> 
-    <Content Include="Views\Stripe\Pay.cshtml" /> 
-    <Content Include="Views\Stripe\Ship.cshtml" /> 
-    <Content Include="Views\UspsShippingTestForm.cshtml" /> 
-  </ItemGroup> 
-  <ItemGroup> 
-    <Content Include="Scripts\order-admin.min.js.map"> 
-      <DependentUpon>order-admin.js</DependentUpon> 
-    </Content> 
-    <Content Include="Scripts\ship.min.js.map"> 
-      <DependentUpon>ship.js</DependentUpon> 
-    </Content> 
-    <Content Include="Styles\order-admin.less" /> 
-    <Content Include="Views\CommerceAddressForm.cshtml" /> 
-    <Content Include="Views\TaxAdmin\Index.cshtml" /> 
-    <Content Include="Views\EditorTemplates\Parts\StateOrCountryTax.cshtml" /> 
-    <Content Include="Views\OrderSummaryAdmin.cshtml" /> 
-    <Content Include="Views\EditorTemplates\Parts\Order.cshtml" /> 
-    <Content Include="Views\Content-Order.SummaryAdmin.cshtml" /> 
-    <Content Include="Views\OrderAdmin\List.cshtml" /> 
-    <Content Include="Views\Order_CheckPassword.cshtml" /> 
-    <Content Include="Views\Order_Confirmation.cshtml" /> 
-  </ItemGroup> 
-  <ItemGroup> 
-    <Content Include="Views\ProductSettingsAdmin\Index.cshtml" /> 
-    <Content Include="Views\PriceTiersAdmin.cshtml" /> 
-    <Content Include="Views\EditorTemplates\Parts\ProductSettings.cshtml" /> 
-    <Content Include="Views\Parts\Product.PriceTiers.cshtml" /> 
-  </ItemGroup> 
-  <ItemGroup> 
-    <Content Include="Views\EditorTemplates\Parts\ZipCodeTax.cshtml" /> 
-  </ItemGroup> 
-  <ItemGroup> 
-    <Content Include="Views\Stripe\SendMoney.cshtml" /> 
-  </ItemGroup> 
-  <ItemGroup> 
-    <Content Include="Scripts\chartjs.min.js.map"> 
-      <DependentUpon>chartjs.js</DependentUpon> 
-    </Content> 
-    <Content Include="Scripts\report.min.js.map"> 
-      <DependentUpon>report.js</DependentUpon> 
-    </Content> 
-    <Content Include="Views\Report\Detail.cshtml" /> 
-    <Content Include="Views\Report\Index.cshtml" /> 
-  </ItemGroup> 
-  <ItemGroup> 
-    <Content Include="Views\TextProductAttributeExtensionInput.cshtml" /> 
-  </ItemGroup> 
-  <ItemGroup> 
-    <Content Include="Views\TextProductAttributeExtensionAdmin.cshtml" /> 
-  </ItemGroup> 
-  <ItemGroup> 
-    <None Include="app.config" /> 
-    <None Include="packages.config" /> 
-  </ItemGroup> 
-  <PropertyGroup> 
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion> 
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath> 
-  </PropertyGroup> 
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" /> 
-  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' = ''" /> 
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" /> 
-  <-- To modify your build process, add your task inside one of the targets below and uncomment it.  
-       Other similar extension points exist, see Microsoft.Common.targets. 
-  <Target Name="BeforeBuild"> 
-  </Target> --> 
-  <Target Name="AfterBuild" DependsOnTargets="AfterBuildCompiler"> 
-    <PropertyGroup> 
-      <AreasManifestDir>$(ProjectDir)\..\Manifests</AreasManifestDir> 
-    </PropertyGroup> 
-    < 
-    <CreateAreaManifest AreaName="$(AssemblyName)" AreaType="Child" AreaPath="$(ProjectDir)" ManifestPath="$(AreasManifestDir)" ContentFiles="@(Content)" /> 
-    --> 
-    < 
-    <CreateAreaManifest AreaName="$(AssemblyName)" AreaType="Parent" AreaPath="$(ProjectDir)" ManifestPath="$(AreasManifestDir)" ContentFiles="@(Content)" /> 
-    <CopyAreaManifests ManifestPath="$(AreasManifestDir)" CrossCopy="false" RenameViews="true" /> 
-    --> 
-  </Target> 
-  <Target Name="AfterBuildCompiler" Condition="'$(MvcBuildViews)'=='true'"> 
-    <AspNetCompiler VirtualPath="temp" PhysicalPath="$(ProjectDir)\..\$(ProjectName)" /> 
-  </Target> 
-  <ProjectExtensions /> 
-  <PropertyGroup> 
-    <PostBuildEvent> 
-    </PostBuildEvent> 
-  </PropertyGroup> 
-</Project> 
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{909ACC2C-D672-4752-B75B-6822E05FE0E3}</ProjectGuid>
+    <ProjectTypeGuids>{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Nwazet.Commerce</RootNamespace>
+    <AssemblyName>Nwazet.Commerce</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <MvcBuildViews>false</MvcBuildViews>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <OldToolsVersion>4.0</OldToolsVersion>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>6</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Orchard.Autoroute">
+      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.Autoroute\bin\Orchard.Autoroute.dll</HintPath>
+    </Reference>
+    <Reference Include="Orchard.Core">
+      <HintPath>..\Orchard.Sources\src\Orchard.Web\Core\bin\Orchard.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Orchard.Fields">
+      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.Fields\bin\Orchard.Fields.dll</HintPath>
+    </Reference>
+    <Reference Include="Orchard.Framework">
+      <HintPath>..\Orchard.Sources\src\Orchard\bin\Debug\Orchard.Framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Orchard.Localization">
+      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.Localization\bin\Orchard.Localization.dll</HintPath>
+    </Reference>
+    <Reference Include="Orchard.MediaLibrary">
+      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.MediaLibrary\bin\Orchard.MediaLibrary.dll</HintPath>
+    </Reference>
+    <Reference Include="Orchard.Roles">
+      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.Roles\bin\Orchard.Roles.dll</HintPath>
+    </Reference>
+    <Reference Include="Orchard.SecureSocketsLayer">
+      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.SecureSocketsLayer\bin\Orchard.SecureSocketsLayer.dll</HintPath>
+    </Reference>
+    <Reference Include="Orchard.Tokens">
+      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.Tokens\bin\Orchard.Tokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Orchard.Workflows">
+      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.Workflows\bin\Orchard.Workflows.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.ComponentModel.DataAnnotations">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Routing" />
+    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Content\accepted-cards.png" />
+    <Content Include="Content\checkout-with-stripe.png" />
+    <Content Include="Content\menu.nwazet-commerce.png" />
+    <Content Include="Content\move.gif" />
+    <Content Include="LICENSE.txt" />
+    <Content Include="Scripts\attribute-admin.js" />
+    <Content Include="Scripts\chartjs.js" />
+    <Content Include="Scripts\chartjs.min.js">
+      <DependentUpon>chartjs.js</DependentUpon>
+    </Content>
+    <Content Include="Scripts\inventory.js" />
+    <Content Include="Scripts\inventory.min.js">
+      <DependentUpon>inventory.js</DependentUpon>
+    </Content>
+    <Content Include="Scripts\jquery.iframe-transport.js" />
+    <Content Include="Scripts\mustache.js" />
+    <Content Include="Scripts\order-admin.js" />
+    <Content Include="Scripts\order-admin.min.js">
+      <DependentUpon>order-admin.js</DependentUpon>
+    </Content>
+    <Content Include="Scripts\referral.js" />
+    <Content Include="Scripts\referral.min.js">
+      <DependentUpon>referral.js</DependentUpon>
+    </Content>
+    <Content Include="Scripts\attribute-extensions.js" />
+    <Content Include="Scripts\report.js" />
+    <Content Include="Scripts\report.min.js">
+      <DependentUpon>report.js</DependentUpon>
+    </Content>
+    <Content Include="Scripts\ship.js" />
+    <Content Include="Scripts\ship.min.js">
+      <DependentUpon>ship.js</DependentUpon>
+    </Content>
+    <Content Include="Scripts\shoppingcart.js">
+      <LastGenOutput>shoppingcart.min.js</LastGenOutput>
+    </Content>
+    <Content Include="Scripts\shoppingcart.min.js">
+      <DependentUpon>shoppingcart.js</DependentUpon>
+    </Content>
+    <Content Include="Styles\bundle.nwazet-commerce-admin.css" />
+    <Content Include="Styles\attribute.nwazet-commerce-admin.css" />
+    <Content Include="Styles\reports-admin.css" />
+    <Content Include="Styles\workflows-activity-order-status-changed-product.css" />
+    <Content Include="Styles\workflows-activity-order-tracking-url-changed.css" />
+    <Content Include="Styles\workflows-activity-new-order.css" />
+    <Content Include="Styles\workflows-activity-order-status-changed.css" />
+    <Content Include="Styles\discount.nwazet-commerce-admin.css" />
+    <Content Include="Styles\menu.nwazet-commerce-admin.css" />
+    <Content Include="Styles\workflows-activity-cart-updated.css" />
+    <Content Include="Styles\order-admin.css">
+      <DependentUpon>order-admin.less</DependentUpon>
+    </Content>
+    <Content Include="Styles\order-admin.min.css">
+      <DependentUpon>order-admin.less</DependentUpon>
+    </Content>
+    <Content Include="Web.config" />
+    <Content Include="Scripts\Web.config" />
+    <Content Include="Properties\AssemblyInfo.cs" />
+    <Content Include="Module.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Activities\CommerceActivity.cs" />
+    <Compile Include="Activities\OrderActivity.cs" />
+    <Compile Include="Controllers\ECommerceSettingsAdminController .cs" />
+    <Compile Include="Controllers\ProductSettingsAdminController.cs" />
+    <Compile Include="Controllers\BundleAdminController.cs" />
+    <Compile Include="Controllers\AttributesAdminController.cs" />
+    <Compile Include="Controllers\OrderAdminController.cs" />
+    <Compile Include="Controllers\OrderSslController.cs" />
+    <Compile Include="Controllers\ReportController.cs" />
+    <Compile Include="Controllers\TaxAdminController.cs" />
+    <Compile Include="Controllers\UspsAdminController.cs" />
+    <Compile Include="Controllers\PromotionAdminController.cs" />
+    <Compile Include="Controllers\ProductAdminController.cs" />
+    <Compile Include="Controllers\ShippingAdminController.cs" />
+    <Compile Include="Controllers\ShoppingCartController.cs" />
+    <Compile Include="Controllers\StripeController.cs" />
+    <Compile Include="Drivers\AdvancedSKUsSiteSettingPartDriver.cs" />
+    <Compile Include="Drivers\BundlePartDriver.cs" />
+    <Compile Include="Drivers\OrderPartDriver.cs" />
+    <Compile Include="Drivers\ProductSettingsPartDriver.cs" />
+    <Compile Include="Drivers\ZipCodeTaxPartDriver.cs" />
+    <Compile Include="Drivers\StateOrCountryTaxPartDriver.cs" />
+    <Compile Include="Drivers\UspsShippingMethodPartDriver.cs" />
+    <Compile Include="Drivers\UspsSettingsPartDriver.cs" />
+    <Compile Include="Drivers\StripeSettingsPartDriver.cs" />
+    <Compile Include="Drivers\ProductAttributesPartDriver.cs" />
+    <Compile Include="Drivers\ProductAttributePartDriver.cs" />
+    <Compile Include="Drivers\DiscountPartDriver.cs" />
+    <Compile Include="Drivers\SizeBasedShippingMethodPartDriver.cs" />
+    <Compile Include="Drivers\ProductPartDriver.cs" />
+    <Compile Include="Drivers\ShoppingCartWidgetDriver.cs" />
+    <Compile Include="Drivers\WeightBasedShippingMethodPartDriver.cs" />
+    <Compile Include="Exceptions\StripeException.cs" />
+    <Compile Include="Filters\ReferrerFilter.cs" />
+    <Compile Include="Handlers\AdvancedSKUManagementHandler.cs" />
+    <Compile Include="Handlers\AdvancedSKUsSiteSettingPartHandler.cs" />
+    <Compile Include="Handlers\BundlePartHandler.cs" />
+    <Compile Include="Handlers\AttributePartHandler.cs" />
+    <Compile Include="Handlers\AttributesPartHandler.cs" />
+    <Compile Include="Handlers\OrderPartHandler.cs" />
+    <Compile Include="Handlers\ProductSettingsPartHandler.cs" />
+    <Compile Include="Handlers\StateOrCountryTaxPartHandler.cs" />
+    <Compile Include="Handlers\UspsShippingMethodPartHandler.cs" />
+    <Compile Include="Handlers\UspsSettingsPartHandler.cs" />
+    <Compile Include="Handlers\StripeSettingsPartHandler.cs" />
+    <Compile Include="Handlers\DiscountPartHandler.cs" />
+    <Compile Include="Handlers\SizeBasedShippingMethodPartHandler.cs" />
+    <Compile Include="Handlers\WeightBasedShippingMethodPartHandler.cs" />
+    <Compile Include="Handlers\ProductPartHandler.cs" />
+    <Compile Include="Menus\ECommerceSettingsAdminMenu.cs" />
+    <Compile Include="Menus\ReportsAdminMenu.cs" />
+    <Compile Include="Menus\ProductSettingsAdminMenu.cs" />
+    <Compile Include="Menus\AttributeAdminMenu.cs" />
+    <Compile Include="Menus\OrderAdminMenu.cs" />
+    <Compile Include="Menus\TaxAdminMenu.cs" />
+    <Compile Include="Menus\PromotionAdminMenu.cs" />
+    <Compile Include="Menus\ProductAdminMenu.cs" />
+    <Compile Include="Menus\ShippingAdminMenu.cs" />
+    <Compile Include="Migrations\BundleMigrations.cs" />
+    <Compile Include="Migrations\CommerceMigrations.cs" />
+    <Compile Include="Migrations\AttributesMigrations.cs" />
+    <Compile Include="Migrations\OrderMigrations.cs" />
+    <Compile Include="Migrations\TaxMigrations.cs" />
+    <Compile Include="Migrations\UspsMigrations.cs" />
+    <Compile Include="Migrations\DiscountMigrations.cs" />
+    <Compile Include="Migrations\ShippingMigrations.cs" />
+    <Compile Include="Models\Address.cs" />
+    <Compile Include="Models\AdvancedSKUsSiteSettingPart.cs" />
+    <Compile Include="Models\CheckoutError.cs" />
+    <Compile Include="Models\CheckoutItem.cs" />
+    <Compile Include="Models\ConversionUtilities.cs" />
+    <Compile Include="Models\Charge.cs" />
+    <Compile Include="Models\ICharge.cs" />
+    <Compile Include="Models\OrderEvent.cs" />
+    <Compile Include="Models\OrderPart.cs" />
+    <Compile Include="Models\OrderPartRecord.cs" />
+    <Compile Include="Models\PriceTier.cs" />
+    <Compile Include="Models\ProductAttributeValue.cs" />
+    <Compile Include="Models\ProductAttributeValueExtended.cs" />
+    <Compile Include="Models\ProductSettingsPart.cs" />
+    <Compile Include="Models\Reporting\ChartType.cs" />
+    <Compile Include="Models\Reporting\ICommerceReport.cs" />
+    <Compile Include="Models\Reporting\ReportData.cs" />
+    <Compile Include="Models\Reporting\ReportDataPoint.cs" />
+    <Compile Include="Models\Reporting\TimePeriod.cs" />
+    <Compile Include="Models\ZipCodeTaxPart.cs" />
+    <Compile Include="Models\StateOrCountryTaxPart.cs" />
+    <Compile Include="Models\StateOrCountryTaxPartRecord.cs" />
+    <Compile Include="Models\CreditCardCharge.cs" />
+    <Compile Include="Models\TaxAmount.cs" />
+    <Compile Include="Models\ShippingException.cs" />
+    <Compile Include="Models\UspsShippingMethodPartRecord.cs" />
+    <Compile Include="Models\UspsSettingsPart.cs" />
+    <Compile Include="Models\ShippingOption.cs" />
+    <Compile Include="Models\UspsShippingOptionList.cs" />
+    <Compile Include="Models\UspsShippingMethodPart.cs" />
+    <Compile Include="Models\StripeSettingsPart.cs" />
+    <Compile Include="Models\ProductAttributesPart.cs" />
+    <Compile Include="Models\ProductAttributesPartRecord.cs" />
+    <Compile Include="Models\ProductAttributePart.cs" />
+    <Compile Include="Models\ProductAttributePartRecord.cs" />
+    <Compile Include="Models\BundlePart.cs" />
+    <Compile Include="Models\BundlePartRecord.cs" />
+    <Compile Include="Models\BundleProductsRecord.cs" />
+    <Compile Include="Models\DiscountPart.cs" />
+    <Compile Include="Models\DiscountPartRecord.cs" />
+    <Compile Include="Models\SizeBasedShippingMethodPart.cs" />
+    <Compile Include="Models\SizeBasedShippingMethodPartRecord.cs" />
+    <Compile Include="Models\ProductPartQuantity.cs" />
+    <Compile Include="Models\ProductQuantity.cs" />
+    <Compile Include="Models\WeightBasedShippingMethodPart.cs" />
+    <Compile Include="Models\WeightBasedShippingMethodPartRecord.cs" />
+    <Compile Include="Models\IProduct.cs" />
+    <Compile Include="Models\IShoppingCart.cs" />
+    <Compile Include="Models\ProductPart.cs" />
+    <Compile Include="Models\ProductPartRecord.cs" />
+    <Compile Include="Models\ShippingArea.cs" />
+    <Compile Include="Models\ShoppingCart.cs" />
+    <Compile Include="Models\ShoppingCartItem.cs" />
+    <Compile Include="Models\ShoppingCartQuantityProduct.cs" />
+    <Compile Include="Models\ShoppingCartWidgetPart.cs" />
+    <Compile Include="Permissions\CommercePermissions.cs" />
+    <Compile Include="Permissions\ReportPermissions.cs" />
+    <Compile Include="Permissions\OrderPermissions.cs" />
+    <Compile Include="Reports\AverageSaleAmountReport.cs" />
+    <Compile Include="Reports\BaseSalesReport.cs" />
+    <Compile Include="Reports\SalesByBestSellingProductsReport.cs" />
+    <Compile Include="Reports\MostProfitableProductsReport.cs" />
+    <Compile Include="Reports\BestSellingProductsReport.cs" />
+    <Compile Include="Reports\TotalSalesReport.cs" />
+    <Compile Include="Reports\NumberOfSalesReport.cs" />
+    <Compile Include="Routes\UspsRoutes.cs" />
+    <Compile Include="Routes\StripeRoutes.cs" />
+    <Compile Include="Routes\OrderRoutes.cs" />
+    <Compile Include="Routes\CommerceRoutes.cs" />
+    <Compile Include="Services\ISKUUniquenessExceptionProvider.cs" />
+    <Compile Include="Services\LocalizationSKUUniquenessExceptionProvider.cs" />
+    <Compile Include="Services\ProductResolverSelector.cs" />
+    <Compile Include="Services\AddressFormatter.cs" />
+    <Compile Include="Services\BundleService.cs" />
+    <Compile Include="Services\Country.cs" />
+    <Compile Include="Services\IProductAttributeExtensionProvider.cs" />
+    <Compile Include="Services\IOrderService.cs" />
+    <Compile Include="Services\IProductAttributeService.cs" />
+    <Compile Include="Services\IStripeWebService.cs" />
+    <Compile Include="Services\ITax.cs" />
+    <Compile Include="Services\ITaxProvider.cs" />
+    <Compile Include="Services\ITieredPriceProvider.cs" />
+    <Compile Include="Services\IUspsService.cs" />
+    <Compile Include="Services\IUspsWebService.cs" />
+    <Compile Include="Services\OrderService.cs" />
+    <Compile Include="Services\ProductAttributeService.cs" />
+    <Compile Include="Services\ProductDiscountPriceProvider.cs" />
+    <Compile Include="Services\ShippingService.cs" />
+    <Compile Include="Services\TextProductAttributeExtensionProvider.cs" />
+    <Compile Include="Services\ZipCodeTaxProvider.cs" />
+    <Compile Include="Services\StateOrCountryTaxProvider.cs" />
+    <Compile Include="Services\StripeWebService.cs" />
+    <Compile Include="Services\TieredPriceProvider.cs" />
+    <Compile Include="Services\UspsContainer.cs" />
+    <Compile Include="Services\UspsService.cs" />
+    <Compile Include="Services\UspsShippingMethodProvider.cs" />
+    <Compile Include="Services\IAddressFormatter.cs" />
+    <Compile Include="Services\StripeService.cs" />
+    <Compile Include="Services\IStripeService.cs" />
+    <Compile Include="Services\Discount.cs" />
+    <Compile Include="Services\DiscountPriceProvider.cs" />
+    <Compile Include="Services\IProductAttributesDriver.cs" />
+    <Compile Include="Services\IPriceProvider.cs" />
+    <Compile Include="Services\IPriceService.cs" />
+    <Compile Include="Services\IPromotion.cs" />
+    <Compile Include="Services\IShoppingCartStorage.cs" />
+    <Compile Include="Services\PriceService.cs" />
+    <Compile Include="Services\ShoppingCartSessionStorage.cs" />
+    <Compile Include="Services\SizeBasedShippingMethodProvider.cs" />
+    <Compile Include="Services\CoreShippingAreas.cs" />
+    <Compile Include="Services\IExtraCartInfoProvider.cs" />
+    <Compile Include="Services\IShippingMethodProvider.cs" />
+    <Compile Include="Services\ReferrerCartInfoProvider.cs" />
+    <Compile Include="Services\ICheckoutService.cs" />
+    <Compile Include="Services\IShippingAreaProvider.cs" />
+    <Compile Include="Services\IShippingMethod.cs" />
+    <Compile Include="Services\UspsWebService.cs" />
+    <Compile Include="Services\WeightBasedShippingMethodProvider.cs" />
+    <Compile Include="Services\UnitedStates.cs" />
+    <Compile Include="Tokens\CartTokens.cs" />
+    <Compile Include="Tokens\OrderTokens.cs" />
+    <Compile Include="Tokens\ProductTokens.cs" />
+    <Compile Include="ViewModels\AdancedSKUsSiteSettingsViewModel.cs" />
+    <Compile Include="ViewModels\ProductAttributePartDisplayViewModel.cs" />
+    <Compile Include="ViewModels\ProductAttributePartEditViewModel.cs" />
+    <Compile Include="ViewModels\AttributesIndexViewModel.cs" />
+    <Compile Include="ViewModels\BundleViewModel.cs" />
+    <Compile Include="ViewModels\ListOrdersViewModel.cs" />
+    <Compile Include="ViewModels\OrderEditorViewModel.cs" />
+    <Compile Include="ViewModels\PricingSettingsViewModel.cs" />
+    <Compile Include="ViewModels\ProductEditorViewModel.cs" />
+    <Compile Include="ViewModels\ReportDataViewModel.cs" />
+    <Compile Include="ViewModels\TaxIndexViewModel.cs" />
+    <Compile Include="ViewModels\DiscountEditorViewModel.cs" />
+    <Compile Include="ViewModels\ProductAttributesPartEditViewModel.cs" />
+    <Compile Include="ViewModels\PromotionIndexViewModel.cs" />
+    <Compile Include="ViewModels\ShippingMethodIndexViewModel.cs" />
+    <Compile Include="ViewModels\StripeCheckoutViewModel.cs" />
+    <Compile Include="ViewModels\UpdateShoppingCartItemViewModel.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Content\Web.config" />
+    <Content Include="placement.info">
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="Views\EditorTemplates\Parts\GoogleCheckoutSettings.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts\Product.cshtml" />
+    <Content Include="Views\Parts\Product.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Styles\Web.config" />
+    <Content Include="Views\ShippingAdmin\Index.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts\WeightBasedShippingMethod.cshtml" />
+    <Content Include="Views\ProductAdmin\List.cshtml" />
+    <Content Include="Views\Parts\Bundle.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts\Bundle.cshtml" />
+    <Content Include="Views\ProductSummaryAdmin.cshtml" />
+    <Content Include="Views\BundleSummaryAdmin.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts\SizeBasedShippingMethod.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts\Discount.cshtml" />
+    <Content Include="Views\Price.cshtml" />
+    <Content Include="Views\PromotionAdmin\Index.cshtml" />
+    <Content Include="Views\ShoppingCart.Summary.cshtml" />
+    <Content Include="Views\Parts\Product.AddButton.cshtml" />
+    <Content Include="Views\ShoppingCart.cshtml" />
+    <Content Include="Views\ShoppingCartWidget.cshtml" />
+    <Content Include="Views\TitleWithLink.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Scripts\inventory.min.js.map">
+      <DependentUpon>inventory.js</DependentUpon>
+    </Content>
+    <Content Include="Scripts\referral.min.js.map">
+      <DependentUpon>referral.js</DependentUpon>
+    </Content>
+    <Content Include="Scripts\shoppingcart.min.js.map">
+      <DependentUpon>shoppingcart.js</DependentUpon>
+    </Content>
+    <Content Include="Views\AttributesAdmin\Index.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts\ProductAttribute.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts\ProductAttributes.cshtml" />
+    <Content Include="Views\Stripe.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts\StripeSettings.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts\UspsShippingMethod.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts\UspsSettings.cshtml" />
+    <Content Include="Views\Parts\ProductAttributes.cshtml" />
+    <Content Include="Views\ShippingInfoForm.cshtml" />
+    <Content Include="Views\ShippingOptions.cshtml" />
+    <Content Include="Views\Stripe\Pay.cshtml" />
+    <Content Include="Views\Stripe\Ship.cshtml" />
+    <Content Include="Views\UspsShippingTestForm.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Scripts\order-admin.min.js.map">
+      <DependentUpon>order-admin.js</DependentUpon>
+    </Content>
+    <Content Include="Scripts\ship.min.js.map">
+      <DependentUpon>ship.js</DependentUpon>
+    </Content>
+    <Content Include="Styles\order-admin.less" />
+    <Content Include="Views\CommerceAddressForm.cshtml" />
+    <Content Include="Views\TaxAdmin\Index.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts\StateOrCountryTax.cshtml" />
+    <Content Include="Views\OrderSummaryAdmin.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts\Order.cshtml" />
+    <Content Include="Views\Content-Order.SummaryAdmin.cshtml" />
+    <Content Include="Views\OrderAdmin\List.cshtml" />
+    <Content Include="Views\Order_CheckPassword.cshtml" />
+    <Content Include="Views\Order_Confirmation.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\ProductSettingsAdmin\Index.cshtml" />
+    <Content Include="Views\PriceTiersAdmin.cshtml" />
+    <Content Include="Views\EditorTemplates\Parts\ProductSettings.cshtml" />
+    <Content Include="Views\Parts\Product.PriceTiers.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\EditorTemplates\Parts\ZipCodeTax.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Stripe\SendMoney.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Scripts\chartjs.min.js.map">
+      <DependentUpon>chartjs.js</DependentUpon>
+    </Content>
+    <Content Include="Scripts\report.min.js.map">
+      <DependentUpon>report.js</DependentUpon>
+    </Content>
+    <Content Include="Views\Report\Detail.cshtml" />
+    <Content Include="Views\Report\Index.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\TextProductAttributeExtensionInput.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\TextProductAttributeExtensionAdmin.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+    <None Include="Views\ECommerceSettingsAdmin\Index.cshtml" />
+    <None Include="Views\EditorTemplates\SiteSettings\AdvancedSKUs.cshtml" />
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target> -->
+  <Target Name="AfterBuild" DependsOnTargets="AfterBuildCompiler">
+    <PropertyGroup>
+      <AreasManifestDir>$(ProjectDir)\..\Manifests</AreasManifestDir>
+    </PropertyGroup>
+    <!-- If this is an area child project, uncomment the following line:
+    <CreateAreaManifest AreaName="$(AssemblyName)" AreaType="Child" AreaPath="$(ProjectDir)" ManifestPath="$(AreasManifestDir)" ContentFiles="@(Content)" />
+    -->
+    <!-- If this is an area parent project, uncomment the following lines:
+    <CreateAreaManifest AreaName="$(AssemblyName)" AreaType="Parent" AreaPath="$(ProjectDir)" ManifestPath="$(AreasManifestDir)" ContentFiles="@(Content)" />
+    <CopyAreaManifests ManifestPath="$(AreasManifestDir)" CrossCopy="false" RenameViews="true" />
+    -->
+  </Target>
+  <Target Name="AfterBuildCompiler" Condition="'$(MvcBuildViews)'=='true'">
+    <AspNetCompiler VirtualPath="temp" PhysicalPath="$(ProjectDir)\..\$(ProjectName)" />
+  </Target>
+  <ProjectExtensions />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/Nwazet.Commerce.csproj
+++ b/Nwazet.Commerce.csproj
@@ -1,534 +1,524 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{909ACC2C-D672-4752-B75B-6822E05FE0E3}</ProjectGuid>
-    <ProjectTypeGuids>{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Nwazet.Commerce</RootNamespace>
-    <AssemblyName>Nwazet.Commerce</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <MvcBuildViews>false</MvcBuildViews>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>4.0</OldToolsVersion>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>6</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Orchard.Autoroute">
-      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.Autoroute\bin\Orchard.Autoroute.dll</HintPath>
-    </Reference>
-    <Reference Include="Orchard.Core">
-      <HintPath>..\Orchard.Sources\src\Orchard.Web\Core\bin\Orchard.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Orchard.Fields">
-      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.Fields\bin\Orchard.Fields.dll</HintPath>
-    </Reference>
-    <Reference Include="Orchard.Framework">
-      <HintPath>..\Orchard.Sources\src\Orchard\bin\Debug\Orchard.Framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Orchard.Localization">
-      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.Localization\bin\Orchard.Localization.dll</HintPath>
-    </Reference>
-    <Reference Include="Orchard.MediaLibrary">
-      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.MediaLibrary\bin\Orchard.MediaLibrary.dll</HintPath>
-    </Reference>
-    <Reference Include="Orchard.Roles">
-      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.Roles\bin\Orchard.Roles.dll</HintPath>
-    </Reference>
-    <Reference Include="Orchard.SecureSocketsLayer">
-      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.SecureSocketsLayer\bin\Orchard.SecureSocketsLayer.dll</HintPath>
-    </Reference>
-    <Reference Include="Orchard.Tokens">
-      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.Tokens\bin\Orchard.Tokens.dll</HintPath>
-    </Reference>
-    <Reference Include="Orchard.Workflows">
-      <HintPath>..\Orchard.Sources\src\Orchard.Web\Modules\Orchard.Workflows\bin\Orchard.Workflows.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.ComponentModel.DataAnnotations">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Web" />
-    <Reference Include="System.Web.Abstractions" />
-    <Reference Include="System.Web.DynamicData" />
-    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Routing" />
-    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Laser.Sources\Laser.Orchard\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Content\accepted-cards.png" />
-    <Content Include="Content\checkout-with-stripe.png" />
-    <Content Include="Content\menu.nwazet-commerce.png" />
-    <Content Include="Content\move.gif" />
-    <Content Include="LICENSE.txt" />
-    <Content Include="Scripts\attribute-admin.js" />
-    <Content Include="Scripts\chartjs.js" />
-    <Content Include="Scripts\chartjs.min.js">
-      <DependentUpon>chartjs.js</DependentUpon>
-    </Content>
-    <Content Include="Scripts\inventory.js" />
-    <Content Include="Scripts\inventory.min.js">
-      <DependentUpon>inventory.js</DependentUpon>
-    </Content>
-    <Content Include="Scripts\jquery.iframe-transport.js" />
-    <Content Include="Scripts\mustache.js" />
-    <Content Include="Scripts\order-admin.js" />
-    <Content Include="Scripts\order-admin.min.js">
-      <DependentUpon>order-admin.js</DependentUpon>
-    </Content>
-    <Content Include="Scripts\referral.js" />
-    <Content Include="Scripts\referral.min.js">
-      <DependentUpon>referral.js</DependentUpon>
-    </Content>
-    <Content Include="Scripts\attribute-extensions.js" />
-    <Content Include="Scripts\report.js" />
-    <Content Include="Scripts\report.min.js">
-      <DependentUpon>report.js</DependentUpon>
-    </Content>
-    <Content Include="Scripts\ship.js" />
-    <Content Include="Scripts\ship.min.js">
-      <DependentUpon>ship.js</DependentUpon>
-    </Content>
-    <Content Include="Scripts\shoppingcart.js">
-      <LastGenOutput>shoppingcart.min.js</LastGenOutput>
-    </Content>
-    <Content Include="Scripts\shoppingcart.min.js">
-      <DependentUpon>shoppingcart.js</DependentUpon>
-    </Content>
-    <Content Include="Styles\bundle.nwazet-commerce-admin.css" />
-    <Content Include="Styles\attribute.nwazet-commerce-admin.css" />
-    <Content Include="Styles\reports-admin.css" />
-    <Content Include="Styles\workflows-activity-order-status-changed-product.css" />
-    <Content Include="Styles\workflows-activity-order-tracking-url-changed.css" />
-    <Content Include="Styles\workflows-activity-new-order.css" />
-    <Content Include="Styles\workflows-activity-order-status-changed.css" />
-    <Content Include="Styles\discount.nwazet-commerce-admin.css" />
-    <Content Include="Styles\menu.nwazet-commerce-admin.css" />
-    <Content Include="Styles\workflows-activity-cart-updated.css" />
-    <Content Include="Styles\order-admin.css">
-      <DependentUpon>order-admin.less</DependentUpon>
-    </Content>
-    <Content Include="Styles\order-admin.min.css">
-      <DependentUpon>order-admin.less</DependentUpon>
-    </Content>
-    <Content Include="Web.config" />
-    <Content Include="Scripts\Web.config" />
-    <Content Include="Properties\AssemblyInfo.cs" />
-    <Content Include="Module.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Activities\CommerceActivity.cs" />
-    <Compile Include="Activities\OrderActivity.cs" />
-    <Compile Include="Controllers\ECommerceSettingsAdminController .cs" />
-    <Compile Include="Controllers\ProductSettingsAdminController.cs" />
-    <Compile Include="Controllers\BundleAdminController.cs" />
-    <Compile Include="Controllers\AttributesAdminController.cs" />
-    <Compile Include="Controllers\OrderAdminController.cs" />
-    <Compile Include="Controllers\OrderSslController.cs" />
-    <Compile Include="Controllers\ReportController.cs" />
-    <Compile Include="Controllers\TaxAdminController.cs" />
-    <Compile Include="Controllers\UspsAdminController.cs" />
-    <Compile Include="Controllers\PromotionAdminController.cs" />
-    <Compile Include="Controllers\ProductAdminController.cs" />
-    <Compile Include="Controllers\ShippingAdminController.cs" />
-    <Compile Include="Controllers\ShoppingCartController.cs" />
-    <Compile Include="Controllers\StripeController.cs" />
-    <Compile Include="Drivers\AdvancedSKUProductPartDriver.cs" />
-    <Compile Include="Drivers\AdvancedSKUsSiteSettingPartDriver.cs" />
-    <Compile Include="Drivers\BundlePartDriver.cs" />
-    <Compile Include="Drivers\OrderPartDriver.cs" />
-    <Compile Include="Drivers\ProductSettingsPartDriver.cs" />
-    <Compile Include="Drivers\ZipCodeTaxPartDriver.cs" />
-    <Compile Include="Drivers\StateOrCountryTaxPartDriver.cs" />
-    <Compile Include="Drivers\UspsShippingMethodPartDriver.cs" />
-    <Compile Include="Drivers\UspsSettingsPartDriver.cs" />
-    <Compile Include="Drivers\StripeSettingsPartDriver.cs" />
-    <Compile Include="Drivers\ProductAttributesPartDriver.cs" />
-    <Compile Include="Drivers\ProductAttributePartDriver.cs" />
-    <Compile Include="Drivers\DiscountPartDriver.cs" />
-    <Compile Include="Drivers\SizeBasedShippingMethodPartDriver.cs" />
-    <Compile Include="Drivers\ProductPartDriver.cs" />
-    <Compile Include="Drivers\ShoppingCartWidgetDriver.cs" />
-    <Compile Include="Drivers\WeightBasedShippingMethodPartDriver.cs" />
-    <Compile Include="Exceptions\StripeException.cs" />
-    <Compile Include="Filters\ReferrerFilter.cs" />
-    <Compile Include="Handlers\AdvancedSKUManagementHandler.cs" />
-    <Compile Include="Handlers\AdvancedSKUsSiteSettingPartHandler.cs" />
-    <Compile Include="Handlers\BundlePartHandler.cs" />
-    <Compile Include="Handlers\AttributePartHandler.cs" />
-    <Compile Include="Handlers\AttributesPartHandler.cs" />
-    <Compile Include="Handlers\OrderPartHandler.cs" />
-    <Compile Include="Handlers\ProductSettingsPartHandler.cs" />
-    <Compile Include="Handlers\StateOrCountryTaxPartHandler.cs" />
-    <Compile Include="Handlers\UspsShippingMethodPartHandler.cs" />
-    <Compile Include="Handlers\UspsSettingsPartHandler.cs" />
-    <Compile Include="Handlers\StripeSettingsPartHandler.cs" />
-    <Compile Include="Handlers\DiscountPartHandler.cs" />
-    <Compile Include="Handlers\SizeBasedShippingMethodPartHandler.cs" />
-    <Compile Include="Handlers\WeightBasedShippingMethodPartHandler.cs" />
-    <Compile Include="Handlers\ProductPartHandler.cs" />
-    <Compile Include="Menus\ECommerceSettingsAdminMenu.cs" />
-    <Compile Include="Menus\ReportsAdminMenu.cs" />
-    <Compile Include="Menus\ProductSettingsAdminMenu.cs" />
-    <Compile Include="Menus\AttributeAdminMenu.cs" />
-    <Compile Include="Menus\OrderAdminMenu.cs" />
-    <Compile Include="Menus\TaxAdminMenu.cs" />
-    <Compile Include="Menus\PromotionAdminMenu.cs" />
-    <Compile Include="Menus\ProductAdminMenu.cs" />
-    <Compile Include="Menus\ShippingAdminMenu.cs" />
-    <Compile Include="Migrations\BundleMigrations.cs" />
-    <Compile Include="Migrations\CommerceMigrations.cs" />
-    <Compile Include="Migrations\AttributesMigrations.cs" />
-    <Compile Include="Migrations\OrderMigrations.cs" />
-    <Compile Include="Migrations\TaxMigrations.cs" />
-    <Compile Include="Migrations\UspsMigrations.cs" />
-    <Compile Include="Migrations\DiscountMigrations.cs" />
-    <Compile Include="Migrations\ShippingMigrations.cs" />
-    <Compile Include="Models\Address.cs" />
-    <Compile Include="Models\AdvancedSKUsSiteSettingPart.cs" />
-    <Compile Include="Models\CheckoutError.cs" />
-    <Compile Include="Models\CheckoutItem.cs" />
-    <Compile Include="Models\ConversionUtilities.cs" />
-    <Compile Include="Models\Charge.cs" />
-    <Compile Include="Models\ICharge.cs" />
-    <Compile Include="Models\OrderEvent.cs" />
-    <Compile Include="Models\OrderPart.cs" />
-    <Compile Include="Models\OrderPartRecord.cs" />
-    <Compile Include="Models\PriceTier.cs" />
-    <Compile Include="Models\ProductAttributeValue.cs" />
-    <Compile Include="Models\ProductAttributeValueExtended.cs" />
-    <Compile Include="Models\ProductSettingsPart.cs" />
-    <Compile Include="Models\Reporting\ChartType.cs" />
-    <Compile Include="Models\Reporting\ICommerceReport.cs" />
-    <Compile Include="Models\Reporting\ReportData.cs" />
-    <Compile Include="Models\Reporting\ReportDataPoint.cs" />
-    <Compile Include="Models\Reporting\TimePeriod.cs" />
-    <Compile Include="Models\ZipCodeTaxPart.cs" />
-    <Compile Include="Models\StateOrCountryTaxPart.cs" />
-    <Compile Include="Models\StateOrCountryTaxPartRecord.cs" />
-    <Compile Include="Models\CreditCardCharge.cs" />
-    <Compile Include="Models\TaxAmount.cs" />
-    <Compile Include="Models\ShippingException.cs" />
-    <Compile Include="Models\UspsShippingMethodPartRecord.cs" />
-    <Compile Include="Models\UspsSettingsPart.cs" />
-    <Compile Include="Models\ShippingOption.cs" />
-    <Compile Include="Models\UspsShippingOptionList.cs" />
-    <Compile Include="Models\UspsShippingMethodPart.cs" />
-    <Compile Include="Models\StripeSettingsPart.cs" />
-    <Compile Include="Models\ProductAttributesPart.cs" />
-    <Compile Include="Models\ProductAttributesPartRecord.cs" />
-    <Compile Include="Models\ProductAttributePart.cs" />
-    <Compile Include="Models\ProductAttributePartRecord.cs" />
-    <Compile Include="Models\BundlePart.cs" />
-    <Compile Include="Models\BundlePartRecord.cs" />
-    <Compile Include="Models\BundleProductsRecord.cs" />
-    <Compile Include="Models\DiscountPart.cs" />
-    <Compile Include="Models\DiscountPartRecord.cs" />
-    <Compile Include="Models\SizeBasedShippingMethodPart.cs" />
-    <Compile Include="Models\SizeBasedShippingMethodPartRecord.cs" />
-    <Compile Include="Models\ProductPartQuantity.cs" />
-    <Compile Include="Models\ProductQuantity.cs" />
-    <Compile Include="Models\WeightBasedShippingMethodPart.cs" />
-    <Compile Include="Models\WeightBasedShippingMethodPartRecord.cs" />
-    <Compile Include="Models\IProduct.cs" />
-    <Compile Include="Models\IShoppingCart.cs" />
-    <Compile Include="Models\ProductPart.cs" />
-    <Compile Include="Models\ProductPartRecord.cs" />
-    <Compile Include="Models\ShippingArea.cs" />
-    <Compile Include="Models\ShoppingCart.cs" />
-    <Compile Include="Models\ShoppingCartItem.cs" />
-    <Compile Include="Models\ShoppingCartQuantityProduct.cs" />
-    <Compile Include="Models\ShoppingCartWidgetPart.cs" />
-    <Compile Include="Permissions\CommercePermissions.cs" />
-    <Compile Include="Permissions\ReportPermissions.cs" />
-    <Compile Include="Permissions\OrderPermissions.cs" />
-    <Compile Include="Reports\AverageSaleAmountReport.cs" />
-    <Compile Include="Reports\BaseSalesReport.cs" />
-    <Compile Include="Reports\SalesByBestSellingProductsReport.cs" />
-    <Compile Include="Reports\MostProfitableProductsReport.cs" />
-    <Compile Include="Reports\BestSellingProductsReport.cs" />
-    <Compile Include="Reports\TotalSalesReport.cs" />
-    <Compile Include="Reports\NumberOfSalesReport.cs" />
-    <Compile Include="Routes\UspsRoutes.cs" />
-    <Compile Include="Routes\StripeRoutes.cs" />
-    <Compile Include="Routes\OrderRoutes.cs" />
-    <Compile Include="Routes\CommerceRoutes.cs" />
-    <Compile Include="Services\ISKUGenerationServices.cs" />
-    <Compile Include="Services\ISKUUniquenessExceptionProvider.cs" />
-    <Compile Include="Services\LocalizationSKUUniquenessExceptionProvider.cs" />
-    <Compile Include="Services\ProductResolverSelector.cs" />
-    <Compile Include="Services\AddressFormatter.cs" />
-    <Compile Include="Services\BundleService.cs" />
-    <Compile Include="Services\Country.cs" />
-    <Compile Include="Services\IProductAttributeExtensionProvider.cs" />
-    <Compile Include="Services\IOrderService.cs" />
-    <Compile Include="Services\IProductAttributeService.cs" />
-    <Compile Include="Services\IStripeWebService.cs" />
-    <Compile Include="Services\ITax.cs" />
-    <Compile Include="Services\ITaxProvider.cs" />
-    <Compile Include="Services\ITieredPriceProvider.cs" />
-    <Compile Include="Services\IUspsService.cs" />
-    <Compile Include="Services\IUspsWebService.cs" />
-    <Compile Include="Services\OrderService.cs" />
-    <Compile Include="Services\ProductAttributeService.cs" />
-    <Compile Include="Services\ProductDiscountPriceProvider.cs" />
-    <Compile Include="Services\ShippingService.cs" />
-    <Compile Include="Services\SKUGenerationServices.cs" />
-    <Compile Include="Services\TextProductAttributeExtensionProvider.cs" />
-    <Compile Include="Services\ZipCodeTaxProvider.cs" />
-    <Compile Include="Services\StateOrCountryTaxProvider.cs" />
-    <Compile Include="Services\StripeWebService.cs" />
-    <Compile Include="Services\TieredPriceProvider.cs" />
-    <Compile Include="Services\UspsContainer.cs" />
-    <Compile Include="Services\UspsService.cs" />
-    <Compile Include="Services\UspsShippingMethodProvider.cs" />
-    <Compile Include="Services\IAddressFormatter.cs" />
-    <Compile Include="Services\StripeService.cs" />
-    <Compile Include="Services\IStripeService.cs" />
-    <Compile Include="Services\Discount.cs" />
-    <Compile Include="Services\DiscountPriceProvider.cs" />
-    <Compile Include="Services\IProductAttributesDriver.cs" />
-    <Compile Include="Services\IPriceProvider.cs" />
-    <Compile Include="Services\IPriceService.cs" />
-    <Compile Include="Services\IPromotion.cs" />
-    <Compile Include="Services\IShoppingCartStorage.cs" />
-    <Compile Include="Services\PriceService.cs" />
-    <Compile Include="Services\ShoppingCartSessionStorage.cs" />
-    <Compile Include="Services\SizeBasedShippingMethodProvider.cs" />
-    <Compile Include="Services\CoreShippingAreas.cs" />
-    <Compile Include="Services\IExtraCartInfoProvider.cs" />
-    <Compile Include="Services\IShippingMethodProvider.cs" />
-    <Compile Include="Services\ReferrerCartInfoProvider.cs" />
-    <Compile Include="Services\ICheckoutService.cs" />
-    <Compile Include="Services\IShippingAreaProvider.cs" />
-    <Compile Include="Services\IShippingMethod.cs" />
-    <Compile Include="Services\UspsWebService.cs" />
-    <Compile Include="Services\WeightBasedShippingMethodProvider.cs" />
-    <Compile Include="Services\UnitedStates.cs" />
-    <Compile Include="Tokens\CartTokens.cs" />
-    <Compile Include="Tokens\OrderTokens.cs" />
-    <Compile Include="Tokens\ProductTokens.cs" />
-    <Compile Include="ViewModels\AdancedSKUsSiteSettingsViewModel.cs" />
-    <Compile Include="ViewModels\AdvancedSKUProductEditorViewModel.cs" />
-    <Compile Include="ViewModels\ProductAttributePartDisplayViewModel.cs" />
-    <Compile Include="ViewModels\ProductAttributePartEditViewModel.cs" />
-    <Compile Include="ViewModels\AttributesIndexViewModel.cs" />
-    <Compile Include="ViewModels\BundleViewModel.cs" />
-    <Compile Include="ViewModels\ListOrdersViewModel.cs" />
-    <Compile Include="ViewModels\OrderEditorViewModel.cs" />
-    <Compile Include="ViewModels\PricingSettingsViewModel.cs" />
-    <Compile Include="ViewModels\ProductEditorViewModel.cs" />
-    <Compile Include="ViewModels\ReportDataViewModel.cs" />
-    <Compile Include="ViewModels\TaxIndexViewModel.cs" />
-    <Compile Include="ViewModels\DiscountEditorViewModel.cs" />
-    <Compile Include="ViewModels\ProductAttributesPartEditViewModel.cs" />
-    <Compile Include="ViewModels\PromotionIndexViewModel.cs" />
-    <Compile Include="ViewModels\ShippingMethodIndexViewModel.cs" />
-    <Compile Include="ViewModels\StripeCheckoutViewModel.cs" />
-    <Compile Include="ViewModels\UpdateShoppingCartItemViewModel.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Content\Web.config" />
-    <Content Include="placement.info">
-      <SubType>Designer</SubType>
-    </Content>
-    <Content Include="Views\EditorTemplates\Parts\GoogleCheckoutSettings.cshtml" />
-    <Content Include="Views\EditorTemplates\Parts\Product.cshtml" />
-    <Content Include="Views\Parts\Product.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Styles\Web.config" />
-    <Content Include="Views\ShippingAdmin\Index.cshtml" />
-    <Content Include="Views\EditorTemplates\Parts\WeightBasedShippingMethod.cshtml" />
-    <Content Include="Views\ProductAdmin\List.cshtml" />
-    <Content Include="Views\Parts\Bundle.cshtml" />
-    <Content Include="Views\EditorTemplates\Parts\Bundle.cshtml" />
-    <Content Include="Views\ProductSummaryAdmin.cshtml" />
-    <Content Include="Views\BundleSummaryAdmin.cshtml" />
-    <Content Include="Views\EditorTemplates\Parts\SizeBasedShippingMethod.cshtml" />
-    <Content Include="Views\EditorTemplates\Parts\Discount.cshtml" />
-    <Content Include="Views\Price.cshtml" />
-    <Content Include="Views\PromotionAdmin\Index.cshtml" />
-    <Content Include="Views\ShoppingCart.Summary.cshtml" />
-    <Content Include="Views\Parts\Product.AddButton.cshtml" />
-    <Content Include="Views\ShoppingCart.cshtml" />
-    <Content Include="Views\ShoppingCartWidget.cshtml" />
-    <Content Include="Views\TitleWithLink.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Scripts\inventory.min.js.map">
-      <DependentUpon>inventory.js</DependentUpon>
-    </Content>
-    <Content Include="Scripts\referral.min.js.map">
-      <DependentUpon>referral.js</DependentUpon>
-    </Content>
-    <Content Include="Scripts\shoppingcart.min.js.map">
-      <DependentUpon>shoppingcart.js</DependentUpon>
-    </Content>
-    <Content Include="Views\AttributesAdmin\Index.cshtml" />
-    <Content Include="Views\EditorTemplates\Parts\ProductAttribute.cshtml" />
-    <Content Include="Views\EditorTemplates\Parts\ProductAttributes.cshtml" />
-    <Content Include="Views\Stripe.cshtml" />
-    <Content Include="Views\EditorTemplates\Parts\StripeSettings.cshtml" />
-    <Content Include="Views\EditorTemplates\Parts\UspsShippingMethod.cshtml" />
-    <Content Include="Views\EditorTemplates\Parts\UspsSettings.cshtml" />
-    <Content Include="Views\Parts\ProductAttributes.cshtml" />
-    <Content Include="Views\ShippingInfoForm.cshtml" />
-    <Content Include="Views\ShippingOptions.cshtml" />
-    <Content Include="Views\Stripe\Pay.cshtml" />
-    <Content Include="Views\Stripe\Ship.cshtml" />
-    <Content Include="Views\UspsShippingTestForm.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Scripts\order-admin.min.js.map">
-      <DependentUpon>order-admin.js</DependentUpon>
-    </Content>
-    <Content Include="Scripts\ship.min.js.map">
-      <DependentUpon>ship.js</DependentUpon>
-    </Content>
-    <Content Include="Styles\order-admin.less" />
-    <Content Include="Views\CommerceAddressForm.cshtml" />
-    <Content Include="Views\TaxAdmin\Index.cshtml" />
-    <Content Include="Views\EditorTemplates\Parts\StateOrCountryTax.cshtml" />
-    <Content Include="Views\OrderSummaryAdmin.cshtml" />
-    <Content Include="Views\EditorTemplates\Parts\Order.cshtml" />
-    <Content Include="Views\Content-Order.SummaryAdmin.cshtml" />
-    <Content Include="Views\OrderAdmin\List.cshtml" />
-    <Content Include="Views\Order_CheckPassword.cshtml" />
-    <Content Include="Views\Order_Confirmation.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Views\ProductSettingsAdmin\Index.cshtml" />
-    <Content Include="Views\PriceTiersAdmin.cshtml" />
-    <Content Include="Views\EditorTemplates\Parts\ProductSettings.cshtml" />
-    <Content Include="Views\Parts\Product.PriceTiers.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Views\EditorTemplates\Parts\ZipCodeTax.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Views\Stripe\SendMoney.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Scripts\chartjs.min.js.map">
-      <DependentUpon>chartjs.js</DependentUpon>
-    </Content>
-    <Content Include="Scripts\report.min.js.map">
-      <DependentUpon>report.js</DependentUpon>
-    </Content>
-    <Content Include="Views\Report\Detail.cshtml" />
-    <Content Include="Views\Report\Index.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Views\TextProductAttributeExtensionInput.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Views\TextProductAttributeExtensionAdmin.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config" />
-    <None Include="Views\ECommerceSettingsAdmin\Index.cshtml" />
-    <None Include="Views\EditorTemplates\Parts\AdvancedSKUProduct.cshtml" />
-    <None Include="Views\EditorTemplates\SiteSettings\AdvancedSKUs.cshtml" />
-  </ItemGroup>
-  <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-  </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target> -->
-  <Target Name="AfterBuild" DependsOnTargets="AfterBuildCompiler">
-    <PropertyGroup>
-      <AreasManifestDir>$(ProjectDir)\..\Manifests</AreasManifestDir>
-    </PropertyGroup>
-    <!-- If this is an area child project, uncomment the following line:
-    <CreateAreaManifest AreaName="$(AssemblyName)" AreaType="Child" AreaPath="$(ProjectDir)" ManifestPath="$(AreasManifestDir)" ContentFiles="@(Content)" />
-    -->
-    <!-- If this is an area parent project, uncomment the following lines:
-    <CreateAreaManifest AreaName="$(AssemblyName)" AreaType="Parent" AreaPath="$(ProjectDir)" ManifestPath="$(AreasManifestDir)" ContentFiles="@(Content)" />
-    <CopyAreaManifests ManifestPath="$(AreasManifestDir)" CrossCopy="false" RenameViews="true" />
-    -->
-  </Target>
-  <Target Name="AfterBuildCompiler" Condition="'$(MvcBuildViews)'=='true'">
-    <AspNetCompiler VirtualPath="temp" PhysicalPath="$(ProjectDir)\..\$(ProjectName)" />
-  </Target>
-  <ProjectExtensions />
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
-</Project>
+﻿<?xml version="1.0" encoding="utf-8"?> 
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"> 
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" /> 
+  <PropertyGroup> 
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration> 
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform> 
+    <ProductVersion>9.0.30729</ProductVersion> 
+    <SchemaVersion>2.0</SchemaVersion> 
+    <ProjectGuid>{909ACC2C-D672-4752-B75B-6822E05FE0E3}</ProjectGuid> 
+    <ProjectTypeGuids>{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids> 
+    <OutputType>Library</OutputType> 
+    <AppDesignerFolder>Properties</AppDesignerFolder> 
+    <RootNamespace>Nwazet.Commerce</RootNamespace> 
+    <AssemblyName>Nwazet.Commerce</AssemblyName> 
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion> 
+    <MvcBuildViews>false</MvcBuildViews> 
+    <FileUpgradeFlags> 
+    </FileUpgradeFlags> 
+    <OldToolsVersion>4.0</OldToolsVersion> 
+    <UpgradeBackupLocation> 
+    </UpgradeBackupLocation> 
+    <TargetFrameworkProfile /> 
+    <NuGetPackageImportStamp> 
+    </NuGetPackageImportStamp> 
+  </PropertyGroup> 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "> 
+    <DebugSymbols>true</DebugSymbols> 
+    <DebugType>full</DebugType> 
+    <Optimize>false</Optimize> 
+    <OutputPath>bin\</OutputPath> 
+    <DefineConstants>DEBUG;TRACE</DefineConstants> 
+    <ErrorReport>prompt</ErrorReport> 
+    <WarningLevel>4</WarningLevel> 
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet> 
+    <Prefer32Bit>false</Prefer32Bit> 
+    <LangVersion>6</LangVersion> 
+  </PropertyGroup> 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "> 
+    <DebugType>full</DebugType> 
+    <Optimize>false</Optimize> 
+    <OutputPath>bin\</OutputPath> 
+    <DefineConstants>TRACE</DefineConstants> 
+    <ErrorReport>prompt</ErrorReport> 
+    <WarningLevel>4</WarningLevel> 
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet> 
+    <Prefer32Bit>false</Prefer32Bit> 
+    <DebugSymbols>true</DebugSymbols> 
+  </PropertyGroup> 
+  <ItemGroup> 
+    <Reference Include="Microsoft.CSharp" /> 
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
+      <HintPath>..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath> 
+      <Private>True</Private> 
+    </Reference> 
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL"> 
+      <HintPath>..\..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath> 
+      <Private>True</Private> 
+    </Reference> 
+    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Autoroute\Orchard.Autoroute.csproj"> 
+      <Project>{66fccd76-2761-47e3-8d11-b45d0001ddaa}</Project> 
+      <Name>Orchard.Autoroute</Name> 
+    </ProjectReference> 
+    <ProjectReference Include="..\..\..\Orchard.Web\Core\Orchard.Core.csproj"> 
+      <Project>{9916839C-39FC-4CEB-A5AF-89CA7E87119F}</Project> 
+      <Name>Orchard.Core</Name> 
+    </ProjectReference> 
+    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Fields\Orchard.Fields.csproj"> 
+      <Project>{3787dde5-e5c8-4841-bda7-dcb325388064}</Project> 
+      <Name>Orchard.Fields</Name> 
+    </ProjectReference> 
+    <ProjectReference Include="..\..\..\Orchard\Orchard.Framework.csproj"> 
+      <Project>{2D1D92BB-4555-4CBE-8D0E-63563D6CE4C6}</Project> 
+      <Name>Orchard.Framework</Name> 
+    </ProjectReference> 
+    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.MediaLibrary\Orchard.MediaLibrary.csproj"> 
+      <Project>{73a7688a-5bd3-4f7e-adfa-ce36c5a10e3b}</Project> 
+      <Name>Orchard.MediaLibrary</Name> 
+    </ProjectReference> 
+    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Roles\Orchard.Roles.csproj"> 
+      <Project>{d10ad48f-407d-4db5-a328-173ec7cb010f}</Project> 
+      <Name>Orchard.Roles</Name> 
+    </ProjectReference> 
+    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.SecureSocketsLayer\Orchard.SecureSocketsLayer.csproj"> 
+      <Project>{36b82383-d69e-4897-a24a-648babdf80ec}</Project> 
+      <Name>Orchard.SecureSocketsLayer</Name> 
+    </ProjectReference> 
+    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Tokens\Orchard.Tokens.csproj"> 
+      <Project>{6f759635-13d7-4e94-bcc9-80445d63f117}</Project> 
+      <Name>Orchard.Tokens</Name> 
+    </ProjectReference> 
+    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Workflows\Orchard.Workflows.csproj"> 
+      <Project>{7059493c-8251-4764-9c1e-2368b8b485bc}</Project> 
+      <Name>Orchard.Workflows</Name> 
+    </ProjectReference> 
+    <Reference Include="System" /> 
+    <Reference Include="System.Data" /> 
+    <Reference Include="System.ComponentModel.DataAnnotations"> 
+      <RequiredTargetFramework>3.5</RequiredTargetFramework> 
+    </Reference> 
+    <Reference Include="System.Web" /> 
+    <Reference Include="System.Web.Abstractions" /> 
+    <Reference Include="System.Web.DynamicData" /> 
+    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
+      <SpecificVersion>False</SpecificVersion> 
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath> 
+    </Reference> 
+    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
+      <HintPath>..\..\..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath> 
+      <Private>True</Private> 
+    </Reference> 
+    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
+      <SpecificVersion>False</SpecificVersion> 
+      <HintPath>..\..\..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath> 
+    </Reference> 
+    <Reference Include="System.Web.Routing" /> 
+    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
+      <SpecificVersion>False</SpecificVersion> 
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath> 
+    </Reference> 
+    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
+      <SpecificVersion>False</SpecificVersion> 
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath> 
+    </Reference> 
+    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL"> 
+      <SpecificVersion>False</SpecificVersion> 
+      <HintPath>..\..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath> 
+    </Reference> 
+    <Reference Include="System.Xml" /> 
+    <Reference Include="System.Configuration" /> 
+    <Reference Include="System.Xml.Linq" /> 
+  </ItemGroup> 
+  <ItemGroup> 
+    <Content Include="Content\accepted-cards.png" /> 
+    <Content Include="Content\checkout-with-stripe.png" /> 
+    <Content Include="Content\menu.nwazet-commerce.png" /> 
+    <Content Include="Content\move.gif" /> 
+    <Content Include="LICENSE.txt" /> 
+    <Content Include="Scripts\attribute-admin.js" /> 
+    <Content Include="Scripts\chartjs.js" /> 
+    <Content Include="Scripts\chartjs.min.js"> 
+      <DependentUpon>chartjs.js</DependentUpon> 
+    </Content> 
+    <Content Include="Scripts\inventory.js" /> 
+    <Content Include="Scripts\inventory.min.js"> 
+      <DependentUpon>inventory.js</DependentUpon> 
+    </Content> 
+    <Content Include="Scripts\jquery.iframe-transport.js" /> 
+    <Content Include="Scripts\mustache.js" /> 
+    <Content Include="Scripts\order-admin.js" /> 
+    <Content Include="Scripts\order-admin.min.js"> 
+      <DependentUpon>order-admin.js</DependentUpon> 
+    </Content> 
+    <Content Include="Scripts\referral.js" /> 
+    <Content Include="Scripts\referral.min.js"> 
+      <DependentUpon>referral.js</DependentUpon> 
+    </Content> 
+    <Content Include="Scripts\attribute-extensions.js" /> 
+    <Content Include="Scripts\report.js" /> 
+    <Content Include="Scripts\report.min.js"> 
+      <DependentUpon>report.js</DependentUpon> 
+    </Content> 
+    <Content Include="Scripts\ship.js" /> 
+    <Content Include="Scripts\ship.min.js"> 
+      <DependentUpon>ship.js</DependentUpon> 
+    </Content> 
+    <Content Include="Scripts\shoppingcart.js"> 
+      <LastGenOutput>shoppingcart.min.js</LastGenOutput> 
+    </Content> 
+    <Content Include="Scripts\shoppingcart.min.js"> 
+      <DependentUpon>shoppingcart.js</DependentUpon> 
+    </Content> 
+    <Content Include="Styles\bundle.nwazet-commerce-admin.css" /> 
+    <Content Include="Styles\attribute.nwazet-commerce-admin.css" /> 
+    <Content Include="Styles\reports-admin.css" /> 
+    <Content Include="Styles\workflows-activity-order-status-changed-product.css" /> 
+    <Content Include="Styles\workflows-activity-order-tracking-url-changed.css" /> 
+    <Content Include="Styles\workflows-activity-new-order.css" /> 
+    <Content Include="Styles\workflows-activity-order-status-changed.css" /> 
+    <Content Include="Styles\discount.nwazet-commerce-admin.css" /> 
+    <Content Include="Styles\menu.nwazet-commerce-admin.css" /> 
+    <Content Include="Styles\workflows-activity-cart-updated.css" /> 
+    <Content Include="Styles\order-admin.css"> 
+      <DependentUpon>order-admin.less</DependentUpon> 
+    </Content> 
+    <Content Include="Styles\order-admin.min.css"> 
+      <DependentUpon>order-admin.less</DependentUpon> 
+    </Content> 
+    <Content Include="Web.config" /> 
+    <Content Include="Scripts\Web.config" /> 
+    <Content Include="Properties\AssemblyInfo.cs" /> 
+    <Content Include="Module.txt" /> 
+  </ItemGroup> 
+  <ItemGroup> 
+    <Compile Include="Activities\CommerceActivity.cs" /> 
+    <Compile Include="Activities\OrderActivity.cs" /> 
+    <Compile Include="Controllers\ProductSettingsAdminController.cs" /> 
+    <Compile Include="Controllers\BundleAdminController.cs" /> 
+    <Compile Include="Controllers\AttributesAdminController.cs" /> 
+    <Compile Include="Controllers\OrderAdminController.cs" /> 
+    <Compile Include="Controllers\OrderSslController.cs" /> 
+    <Compile Include="Controllers\ReportController.cs" /> 
+    <Compile Include="Controllers\TaxAdminController.cs" /> 
+    <Compile Include="Controllers\UspsAdminController.cs" /> 
+    <Compile Include="Controllers\PromotionAdminController.cs" /> 
+    <Compile Include="Controllers\ProductAdminController.cs" /> 
+    <Compile Include="Controllers\ShippingAdminController.cs" /> 
+    <Compile Include="Controllers\ShoppingCartController.cs" /> 
+    <Compile Include="Controllers\StripeController.cs" /> 
+    <Compile Include="Drivers\BundlePartDriver.cs" /> 
+    <Compile Include="Drivers\OrderPartDriver.cs" /> 
+    <Compile Include="Drivers\ProductSettingsPartDriver.cs" /> 
+    <Compile Include="Drivers\ZipCodeTaxPartDriver.cs" /> 
+    <Compile Include="Drivers\StateOrCountryTaxPartDriver.cs" /> 
+    <Compile Include="Drivers\UspsShippingMethodPartDriver.cs" /> 
+    <Compile Include="Drivers\UspsSettingsPartDriver.cs" /> 
+    <Compile Include="Drivers\StripeSettingsPartDriver.cs" /> 
+    <Compile Include="Drivers\ProductAttributesPartDriver.cs" /> 
+    <Compile Include="Drivers\ProductAttributePartDriver.cs" /> 
+    <Compile Include="Drivers\DiscountPartDriver.cs" /> 
+    <Compile Include="Drivers\SizeBasedShippingMethodPartDriver.cs" /> 
+    <Compile Include="Drivers\ProductPartDriver.cs" /> 
+    <Compile Include="Drivers\ShoppingCartWidgetDriver.cs" /> 
+    <Compile Include="Drivers\WeightBasedShippingMethodPartDriver.cs" /> 
+    <Compile Include="Exceptions\StripeException.cs" /> 
+    <Compile Include="Filters\ReferrerFilter.cs" /> 
+    <Compile Include="Handlers\BundlePartHandler.cs" /> 
+    <Compile Include="Handlers\AttributePartHandler.cs" /> 
+    <Compile Include="Handlers\AttributesPartHandler.cs" /> 
+    <Compile Include="Handlers\OrderPartHandler.cs" /> 
+    <Compile Include="Handlers\ProductSettingsPartHandler.cs" /> 
+    <Compile Include="Handlers\StateOrCountryTaxPartHandler.cs" /> 
+    <Compile Include="Handlers\UspsShippingMethodPartHandler.cs" /> 
+    <Compile Include="Handlers\UspsSettingsPartHandler.cs" /> 
+    <Compile Include="Handlers\StripeSettingsPartHandler.cs" /> 
+    <Compile Include="Handlers\DiscountPartHandler.cs" /> 
+    <Compile Include="Handlers\SizeBasedShippingMethodPartHandler.cs" /> 
+    <Compile Include="Handlers\WeightBasedShippingMethodPartHandler.cs" /> 
+    <Compile Include="Handlers\ProductPartHandler.cs" /> 
+    <Compile Include="Menus\ReportsAdminMenu.cs" /> 
+    <Compile Include="Menus\ProductSettingsAdminMenu.cs" /> 
+    <Compile Include="Menus\AttributeAdminMenu.cs" /> 
+    <Compile Include="Menus\OrderAdminMenu.cs" /> 
+    <Compile Include="Menus\TaxAdminMenu.cs" /> 
+    <Compile Include="Menus\PromotionAdminMenu.cs" /> 
+    <Compile Include="Menus\ProductAdminMenu.cs" /> 
+    <Compile Include="Menus\ShippingAdminMenu.cs" /> 
+    <Compile Include="Migrations\BundleMigrations.cs" /> 
+    <Compile Include="Migrations\CommerceMigrations.cs" /> 
+    <Compile Include="Migrations\AttributesMigrations.cs" /> 
+    <Compile Include="Migrations\OrderMigrations.cs" /> 
+    <Compile Include="Migrations\TaxMigrations.cs" /> 
+    <Compile Include="Migrations\UspsMigrations.cs" /> 
+    <Compile Include="Migrations\DiscountMigrations.cs" /> 
+    <Compile Include="Migrations\ShippingMigrations.cs" /> 
+    <Compile Include="Models\Address.cs" /> 
+    <Compile Include="Models\CheckoutError.cs" /> 
+    <Compile Include="Models\CheckoutItem.cs" /> 
+    <Compile Include="Models\ConversionUtilities.cs" /> 
+    <Compile Include="Models\Charge.cs" /> 
+    <Compile Include="Models\ICharge.cs" /> 
+    <Compile Include="Models\OrderEvent.cs" /> 
+    <Compile Include="Models\OrderPart.cs" /> 
+    <Compile Include="Models\OrderPartRecord.cs" /> 
+    <Compile Include="Models\PriceTier.cs" /> 
+    <Compile Include="Models\ProductAttributeValue.cs" /> 
+    <Compile Include="Models\ProductAttributeValueExtended.cs" /> 
+    <Compile Include="Models\ProductSettingsPart.cs" /> 
+    <Compile Include="Models\Reporting\ChartType.cs" /> 
+    <Compile Include="Models\Reporting\ICommerceReport.cs" /> 
+    <Compile Include="Models\Reporting\ReportData.cs" /> 
+    <Compile Include="Models\Reporting\ReportDataPoint.cs" /> 
+    <Compile Include="Models\Reporting\TimePeriod.cs" /> 
+    <Compile Include="Models\ZipCodeTaxPart.cs" /> 
+    <Compile Include="Models\StateOrCountryTaxPart.cs" /> 
+    <Compile Include="Models\StateOrCountryTaxPartRecord.cs" /> 
+    <Compile Include="Models\CreditCardCharge.cs" /> 
+    <Compile Include="Models\TaxAmount.cs" /> 
+    <Compile Include="Models\ShippingException.cs" /> 
+    <Compile Include="Models\UspsShippingMethodPartRecord.cs" /> 
+    <Compile Include="Models\UspsSettingsPart.cs" /> 
+    <Compile Include="Models\ShippingOption.cs" /> 
+    <Compile Include="Models\UspsShippingOptionList.cs" /> 
+    <Compile Include="Models\UspsShippingMethodPart.cs" /> 
+    <Compile Include="Models\StripeSettingsPart.cs" /> 
+    <Compile Include="Models\ProductAttributesPart.cs" /> 
+    <Compile Include="Models\ProductAttributesPartRecord.cs" /> 
+    <Compile Include="Models\ProductAttributePart.cs" /> 
+    <Compile Include="Models\ProductAttributePartRecord.cs" /> 
+    <Compile Include="Models\BundlePart.cs" /> 
+    <Compile Include="Models\BundlePartRecord.cs" /> 
+    <Compile Include="Models\BundleProductsRecord.cs" /> 
+    <Compile Include="Models\DiscountPart.cs" /> 
+    <Compile Include="Models\DiscountPartRecord.cs" /> 
+    <Compile Include="Models\SizeBasedShippingMethodPart.cs" /> 
+    <Compile Include="Models\SizeBasedShippingMethodPartRecord.cs" /> 
+    <Compile Include="Models\ProductPartQuantity.cs" /> 
+    <Compile Include="Models\ProductQuantity.cs" /> 
+    <Compile Include="Models\WeightBasedShippingMethodPart.cs" /> 
+    <Compile Include="Models\WeightBasedShippingMethodPartRecord.cs" /> 
+    <Compile Include="Models\IProduct.cs" /> 
+    <Compile Include="Models\IShoppingCart.cs" /> 
+    <Compile Include="Models\ProductPart.cs" /> 
+    <Compile Include="Models\ProductPartRecord.cs" /> 
+    <Compile Include="Models\ShippingArea.cs" /> 
+    <Compile Include="Models\ShoppingCart.cs" /> 
+    <Compile Include="Models\ShoppingCartItem.cs" /> 
+    <Compile Include="Models\ShoppingCartQuantityProduct.cs" /> 
+    <Compile Include="Models\ShoppingCartWidgetPart.cs" /> 
+    <Compile Include="Permissions\CommercePermissions.cs" /> 
+    <Compile Include="Permissions\ReportPermissions.cs" /> 
+    <Compile Include="Permissions\OrderPermissions.cs" /> 
+    <Compile Include="Reports\AverageSaleAmountReport.cs" /> 
+    <Compile Include="Reports\BaseSalesReport.cs" /> 
+    <Compile Include="Reports\SalesByBestSellingProductsReport.cs" /> 
+    <Compile Include="Reports\MostProfitableProductsReport.cs" /> 
+    <Compile Include="Reports\BestSellingProductsReport.cs" /> 
+    <Compile Include="Reports\TotalSalesReport.cs" /> 
+    <Compile Include="Reports\NumberOfSalesReport.cs" /> 
+    <Compile Include="Routes\UspsRoutes.cs" /> 
+    <Compile Include="Routes\StripeRoutes.cs" /> 
+    <Compile Include="Routes\OrderRoutes.cs" /> 
+    <Compile Include="Routes\CommerceRoutes.cs" /> 
+    <Compile Include="Services\ProductResolverSelector.cs" /> 
+    <Compile Include="Services\AddressFormatter.cs" /> 
+    <Compile Include="Services\BundleService.cs" /> 
+    <Compile Include="Services\Country.cs" /> 
+    <Compile Include="Services\IProductAttributeExtensionProvider.cs" /> 
+    <Compile Include="Services\IOrderService.cs" /> 
+    <Compile Include="Services\IProductAttributeService.cs" /> 
+    <Compile Include="Services\IStripeWebService.cs" /> 
+    <Compile Include="Services\ITax.cs" /> 
+    <Compile Include="Services\ITaxProvider.cs" /> 
+    <Compile Include="Services\ITieredPriceProvider.cs" /> 
+    <Compile Include="Services\IUspsService.cs" /> 
+    <Compile Include="Services\IUspsWebService.cs" /> 
+    <Compile Include="Services\OrderService.cs" /> 
+    <Compile Include="Services\ProductAttributeService.cs" /> 
+    <Compile Include="Services\ProductDiscountPriceProvider.cs" /> 
+    <Compile Include="Services\ShippingService.cs" /> 
+    <Compile Include="Services\TextProductAttributeExtensionProvider.cs" /> 
+    <Compile Include="Services\ZipCodeTaxProvider.cs" /> 
+    <Compile Include="Services\StateOrCountryTaxProvider.cs" /> 
+    <Compile Include="Services\StripeWebService.cs" /> 
+    <Compile Include="Services\TieredPriceProvider.cs" /> 
+    <Compile Include="Services\UspsContainer.cs" /> 
+    <Compile Include="Services\UspsService.cs" /> 
+    <Compile Include="Services\UspsShippingMethodProvider.cs" /> 
+    <Compile Include="Services\IAddressFormatter.cs" /> 
+    <Compile Include="Services\StripeService.cs" /> 
+    <Compile Include="Services\IStripeService.cs" /> 
+    <Compile Include="Services\Discount.cs" /> 
+    <Compile Include="Services\DiscountPriceProvider.cs" /> 
+    <Compile Include="Services\IProductAttributesDriver.cs" /> 
+    <Compile Include="Services\IPriceProvider.cs" /> 
+    <Compile Include="Services\IPriceService.cs" /> 
+    <Compile Include="Services\IPromotion.cs" /> 
+    <Compile Include="Services\IShoppingCartStorage.cs" /> 
+    <Compile Include="Services\PriceService.cs" /> 
+    <Compile Include="Services\ShoppingCartSessionStorage.cs" /> 
+    <Compile Include="Services\SizeBasedShippingMethodProvider.cs" /> 
+    <Compile Include="Services\CoreShippingAreas.cs" /> 
+    <Compile Include="Services\IExtraCartInfoProvider.cs" /> 
+    <Compile Include="Services\IShippingMethodProvider.cs" /> 
+    <Compile Include="Services\ReferrerCartInfoProvider.cs" /> 
+    <Compile Include="Services\ICheckoutService.cs" /> 
+    <Compile Include="Services\IShippingAreaProvider.cs" /> 
+    <Compile Include="Services\IShippingMethod.cs" /> 
+    <Compile Include="Services\UspsWebService.cs" /> 
+    <Compile Include="Services\WeightBasedShippingMethodProvider.cs" /> 
+    <Compile Include="Services\UnitedStates.cs" /> 
+    <Compile Include="Tokens\CartTokens.cs" /> 
+    <Compile Include="Tokens\OrderTokens.cs" /> 
+    <Compile Include="Tokens\ProductTokens.cs" /> 
+    <Compile Include="ViewModels\ProductAttributePartDisplayViewModel.cs" /> 
+    <Compile Include="ViewModels\ProductAttributePartEditViewModel.cs" /> 
+    <Compile Include="ViewModels\AttributesIndexViewModel.cs" /> 
+    <Compile Include="ViewModels\BundleViewModel.cs" /> 
+    <Compile Include="ViewModels\ListOrdersViewModel.cs" /> 
+    <Compile Include="ViewModels\OrderEditorViewModel.cs" /> 
+    <Compile Include="ViewModels\PricingSettingsViewModel.cs" /> 
+    <Compile Include="ViewModels\ProductEditorViewModel.cs" /> 
+    <Compile Include="ViewModels\ReportDataViewModel.cs" /> 
+    <Compile Include="ViewModels\TaxIndexViewModel.cs" /> 
+    <Compile Include="ViewModels\DiscountEditorViewModel.cs" /> 
+    <Compile Include="ViewModels\ProductAttributesPartEditViewModel.cs" /> 
+    <Compile Include="ViewModels\PromotionIndexViewModel.cs" /> 
+    <Compile Include="ViewModels\ShippingMethodIndexViewModel.cs" /> 
+    <Compile Include="ViewModels\StripeCheckoutViewModel.cs" /> 
+    <Compile Include="ViewModels\UpdateShoppingCartItemViewModel.cs" /> 
+  </ItemGroup> 
+  <ItemGroup> 
+    <Content Include="Content\Web.config" /> 
+    <Content Include="placement.info"> 
+      <SubType>Designer</SubType> 
+    </Content> 
+    <Content Include="Views\EditorTemplates\Parts\GoogleCheckoutSettings.cshtml" /> 
+    <Content Include="Views\EditorTemplates\Parts\Product.cshtml" /> 
+    <Content Include="Views\Parts\Product.cshtml" /> 
+  </ItemGroup> 
+  <ItemGroup> 
+    <Content Include="Styles\Web.config" /> 
+    <Content Include="Views\ShippingAdmin\Index.cshtml" /> 
+    <Content Include="Views\EditorTemplates\Parts\WeightBasedShippingMethod.cshtml" /> 
+    <Content Include="Views\ProductAdmin\List.cshtml" /> 
+    <Content Include="Views\Parts\Bundle.cshtml" /> 
+    <Content Include="Views\EditorTemplates\Parts\Bundle.cshtml" /> 
+    <Content Include="Views\ProductSummaryAdmin.cshtml" /> 
+    <Content Include="Views\BundleSummaryAdmin.cshtml" /> 
+    <Content Include="Views\EditorTemplates\Parts\SizeBasedShippingMethod.cshtml" /> 
+    <Content Include="Views\EditorTemplates\Parts\Discount.cshtml" /> 
+    <Content Include="Views\Price.cshtml" /> 
+    <Content Include="Views\PromotionAdmin\Index.cshtml" /> 
+    <Content Include="Views\ShoppingCart.Summary.cshtml" /> 
+    <Content Include="Views\Parts\Product.AddButton.cshtml" /> 
+    <Content Include="Views\ShoppingCart.cshtml" /> 
+    <Content Include="Views\ShoppingCartWidget.cshtml" /> 
+    <Content Include="Views\TitleWithLink.cshtml" /> 
+  </ItemGroup> 
+  <ItemGroup> 
+    <Content Include="Scripts\inventory.min.js.map"> 
+      <DependentUpon>inventory.js</DependentUpon> 
+    </Content> 
+    <Content Include="Scripts\referral.min.js.map"> 
+      <DependentUpon>referral.js</DependentUpon> 
+    </Content> 
+    <Content Include="Scripts\shoppingcart.min.js.map"> 
+      <DependentUpon>shoppingcart.js</DependentUpon> 
+    </Content> 
+    <Content Include="Views\AttributesAdmin\Index.cshtml" /> 
+    <Content Include="Views\EditorTemplates\Parts\ProductAttribute.cshtml" /> 
+    <Content Include="Views\EditorTemplates\Parts\ProductAttributes.cshtml" /> 
+    <Content Include="Views\Stripe.cshtml" /> 
+    <Content Include="Views\EditorTemplates\Parts\StripeSettings.cshtml" /> 
+    <Content Include="Views\EditorTemplates\Parts\UspsShippingMethod.cshtml" /> 
+    <Content Include="Views\EditorTemplates\Parts\UspsSettings.cshtml" /> 
+    <Content Include="Views\Parts\ProductAttributes.cshtml" /> 
+    <Content Include="Views\ShippingInfoForm.cshtml" /> 
+    <Content Include="Views\ShippingOptions.cshtml" /> 
+    <Content Include="Views\Stripe\Pay.cshtml" /> 
+    <Content Include="Views\Stripe\Ship.cshtml" /> 
+    <Content Include="Views\UspsShippingTestForm.cshtml" /> 
+  </ItemGroup> 
+  <ItemGroup> 
+    <Content Include="Scripts\order-admin.min.js.map"> 
+      <DependentUpon>order-admin.js</DependentUpon> 
+    </Content> 
+    <Content Include="Scripts\ship.min.js.map"> 
+      <DependentUpon>ship.js</DependentUpon> 
+    </Content> 
+    <Content Include="Styles\order-admin.less" /> 
+    <Content Include="Views\CommerceAddressForm.cshtml" /> 
+    <Content Include="Views\TaxAdmin\Index.cshtml" /> 
+    <Content Include="Views\EditorTemplates\Parts\StateOrCountryTax.cshtml" /> 
+    <Content Include="Views\OrderSummaryAdmin.cshtml" /> 
+    <Content Include="Views\EditorTemplates\Parts\Order.cshtml" /> 
+    <Content Include="Views\Content-Order.SummaryAdmin.cshtml" /> 
+    <Content Include="Views\OrderAdmin\List.cshtml" /> 
+    <Content Include="Views\Order_CheckPassword.cshtml" /> 
+    <Content Include="Views\Order_Confirmation.cshtml" /> 
+  </ItemGroup> 
+  <ItemGroup> 
+    <Content Include="Views\ProductSettingsAdmin\Index.cshtml" /> 
+    <Content Include="Views\PriceTiersAdmin.cshtml" /> 
+    <Content Include="Views\EditorTemplates\Parts\ProductSettings.cshtml" /> 
+    <Content Include="Views\Parts\Product.PriceTiers.cshtml" /> 
+  </ItemGroup> 
+  <ItemGroup> 
+    <Content Include="Views\EditorTemplates\Parts\ZipCodeTax.cshtml" /> 
+  </ItemGroup> 
+  <ItemGroup> 
+    <Content Include="Views\Stripe\SendMoney.cshtml" /> 
+  </ItemGroup> 
+  <ItemGroup> 
+    <Content Include="Scripts\chartjs.min.js.map"> 
+      <DependentUpon>chartjs.js</DependentUpon> 
+    </Content> 
+    <Content Include="Scripts\report.min.js.map"> 
+      <DependentUpon>report.js</DependentUpon> 
+    </Content> 
+    <Content Include="Views\Report\Detail.cshtml" /> 
+    <Content Include="Views\Report\Index.cshtml" /> 
+  </ItemGroup> 
+  <ItemGroup> 
+    <Content Include="Views\TextProductAttributeExtensionInput.cshtml" /> 
+  </ItemGroup> 
+  <ItemGroup> 
+    <Content Include="Views\TextProductAttributeExtensionAdmin.cshtml" /> 
+  </ItemGroup> 
+  <ItemGroup> 
+    <None Include="app.config" /> 
+    <None Include="packages.config" /> 
+  </ItemGroup> 
+  <PropertyGroup> 
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion> 
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath> 
+  </PropertyGroup> 
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" /> 
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' = ''" /> 
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" /> 
+  <-- To modify your build process, add your task inside one of the targets below and uncomment it.  
+       Other similar extension points exist, see Microsoft.Common.targets. 
+  <Target Name="BeforeBuild"> 
+  </Target> --> 
+  <Target Name="AfterBuild" DependsOnTargets="AfterBuildCompiler"> 
+    <PropertyGroup> 
+      <AreasManifestDir>$(ProjectDir)\..\Manifests</AreasManifestDir> 
+    </PropertyGroup> 
+    < 
+    <CreateAreaManifest AreaName="$(AssemblyName)" AreaType="Child" AreaPath="$(ProjectDir)" ManifestPath="$(AreasManifestDir)" ContentFiles="@(Content)" /> 
+    --> 
+    < 
+    <CreateAreaManifest AreaName="$(AssemblyName)" AreaType="Parent" AreaPath="$(ProjectDir)" ManifestPath="$(AreasManifestDir)" ContentFiles="@(Content)" /> 
+    <CopyAreaManifests ManifestPath="$(AreasManifestDir)" CrossCopy="false" RenameViews="true" /> 
+    --> 
+  </Target> 
+  <Target Name="AfterBuildCompiler" Condition="'$(MvcBuildViews)'=='true'"> 
+    <AspNetCompiler VirtualPath="temp" PhysicalPath="$(ProjectDir)\..\$(ProjectName)" /> 
+  </Target> 
+  <ProjectExtensions /> 
+  <PropertyGroup> 
+    <PostBuildEvent> 
+    </PostBuildEvent> 
+  </PropertyGroup> 
+</Project> 

--- a/Nwazet.Commerce.csproj
+++ b/Nwazet.Commerce.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Controllers\ShippingAdminController.cs" />
     <Compile Include="Controllers\ShoppingCartController.cs" />
     <Compile Include="Controllers\StripeController.cs" />
+    <Compile Include="Drivers\AdvancedSKUProductPartDriver.cs" />
     <Compile Include="Drivers\AdvancedSKUsSiteSettingPartDriver.cs" />
     <Compile Include="Drivers\BundlePartDriver.cs" />
     <Compile Include="Drivers\OrderPartDriver.cs" />
@@ -376,6 +377,7 @@
     <Compile Include="Tokens\OrderTokens.cs" />
     <Compile Include="Tokens\ProductTokens.cs" />
     <Compile Include="ViewModels\AdancedSKUsSiteSettingsViewModel.cs" />
+    <Compile Include="ViewModels\AdvancedSKUProductEditorViewModel.cs" />
     <Compile Include="ViewModels\ProductAttributePartDisplayViewModel.cs" />
     <Compile Include="ViewModels\ProductAttributePartEditViewModel.cs" />
     <Compile Include="ViewModels\AttributesIndexViewModel.cs" />
@@ -495,6 +497,7 @@
     <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Views\ECommerceSettingsAdmin\Index.cshtml" />
+    <None Include="Views\EditorTemplates\Parts\AdvancedSKUProduct.cshtml" />
     <None Include="Views\EditorTemplates\SiteSettings\AdvancedSKUs.cshtml" />
   </ItemGroup>
   <PropertyGroup>

--- a/Services/ISKUGenerationServices.cs
+++ b/Services/ISKUGenerationServices.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nwazet.Commerce.Models;
+using Orchard;
+
+namespace Nwazet.Commerce.Services {
+    public interface ISKUGenerationServices : IDependency {
+
+        AdvancedSKUsSiteSettingPart GetSettings();
+        /// <summary>
+        /// Generate a new SKU for the product. Usually, before calling this method you should check 
+        /// GetSettings().GenerateSKUAutomatically. Implementations of this method are not
+        /// guaranteed to not have side effects.
+        /// </summary>
+        /// <param name="part"></param>
+        /// <returns>The newly generated sku.</returns>
+        string GenerateSku(ProductPart part);
+        /// <summary>
+        /// Process the SKU to handle duplicate cases. The sku of the ProductPart may change if
+        /// it was not unique.
+        /// </summary>
+        /// <param name="part"></param>
+        /// <returns>False if the SKU of the ProductPart was found not unique and changed. True if the SKU has not changed.</returns>
+        bool ProcessSku(ProductPart part);
+    }
+}

--- a/Services/ISKUGenerationServices.cs
+++ b/Services/ISKUGenerationServices.cs
@@ -25,5 +25,7 @@ namespace Nwazet.Commerce.Services {
         /// <param name="part"></param>
         /// <returns>False if the SKU of the ProductPart was found not unique and changed. True if the SKU has not changed.</returns>
         bool ProcessSku(ProductPart part);
+
+        string DefaultSkuPattern { get; }
     }
 }

--- a/Services/ISKUUniquenessExceptionProvider.cs
+++ b/Services/ISKUUniquenessExceptionProvider.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nwazet.Commerce.Models;
+using Orchard;
+using Orchard.Environment.Extensions;
+
+namespace Nwazet.Commerce.Services {
+    public interface ISKUUniquenessExceptionProvider : IDependency {
+        /// <summary>
+        /// This method returns the Ids of he ProductParts that are allowed to have the same SKU as the part
+        /// passed as parameter.
+        /// </summary>
+        /// <param name="part">The ProductPart of which we want to find the valid SKU duplicates.</param>
+        /// <returns>The Ids of ProductParts that are allowed to have the same SKU.</returns>
+        IEnumerable<int> GetIdsOfValidSKUDuplicates(ProductPart part);
+    }
+}

--- a/Services/LocalizationSKUUniquenessExceptionProvider.cs
+++ b/Services/LocalizationSKUUniquenessExceptionProvider.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nwazet.Commerce.Models;
+using Orchard.ContentManagement;
+using Orchard.Environment.Extensions;
+using Orchard.Localization.Models;
+using Orchard.Localization.Services;
+
+namespace Nwazet.Commerce.Services {
+    [OrchardFeature("Nwazet.AdvancedSKUManagement")]
+    public class LocalizationSKUUniquenessExceptionProvider : ISKUUniquenessExceptionProvider {
+
+        private readonly ILocalizationService _localizationService;
+        public LocalizationSKUUniquenessExceptionProvider(ILocalizationService localizationService) {
+            _localizationService = localizationService;
+        }
+
+        public IEnumerable<int> GetIdsOfValidSKUDuplicates(ProductPart part) {
+            LocalizationPart lPart = part.ContentItem.As<LocalizationPart>();
+            if (lPart == null) {
+                //the ContentItem is not Localizabel so this does not apply
+                return new int[0];
+            }
+            return _localizationService.GetLocalizations(part.ContentItem, VersionOptions.Latest).Select(ci => ci.Id);
+        }
+    }
+}

--- a/Services/SKUGenerationServices.cs
+++ b/Services/SKUGenerationServices.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nwazet.Commerce.Models;
+using Orchard;
+using Orchard.ContentManagement;
+using Orchard.Environment.Extensions;
+using Orchard.Tokens;
+
+namespace Nwazet.Commerce.Services {
+    [OrchardFeature("Nwazet.AdvancedSKUManagement")]
+    public class SKUGenerationServices : ISKUGenerationServices {
+
+        private readonly IOrchardServices _orchardServices;
+        private readonly ITokenizer _tokenizer;
+        private readonly IEnumerable<ISKUUniquenessExceptionProvider> _SKUUniquenessExceptionProviders;
+        private readonly IContentManager _contentManager;
+
+        public SKUGenerationServices(IOrchardServices orchardServices,
+            ITokenizer tokenizer,
+            IEnumerable<ISKUUniquenessExceptionProvider> SKUUniquenessExceptionProviders,
+            IContentManager contentManager) {
+
+            _orchardServices = orchardServices;
+            _tokenizer = tokenizer;
+            _SKUUniquenessExceptionProviders = SKUUniquenessExceptionProviders;
+            _contentManager = contentManager;
+        }
+        private AdvancedSKUsSiteSettingPart Settings { get; set; }
+        public AdvancedSKUsSiteSettingPart GetSettings() {
+            if (Settings == null) {
+                Settings = _orchardServices.WorkContext.CurrentSite.As<AdvancedSKUsSiteSettingPart>();
+            }
+            return Settings;
+        }
+
+        private IDictionary<string, object> BuildTokenContext(IContent item) {
+            return new Dictionary<string, object> { { "Content", item } };
+        }
+
+        public string GenerateSku(ProductPart part) {
+            if (part == null) {
+                throw new ArgumentNullException("part");
+            }
+            var pattern = GetSettings().SKUPattern;
+            if (Settings.AllowCustomPattern && !string.IsNullOrWhiteSpace(part.Sku)) {
+                pattern = part.Sku;
+            }
+            if (string.IsNullOrWhiteSpace(pattern)) {
+                //use a default pattern
+                pattern = "SKU-{Content.Id}";
+            }
+            var sku = _tokenizer.Replace(pattern, 
+                BuildTokenContext(part.ContentItem), 
+                new ReplaceOptions { Encoding = ReplaceOptions.NoEncode });
+
+            return sku;
+        }
+
+        private static int? GetSkuVersion(string sku, string conflictingSku) {
+            int v;
+            var skuParts = conflictingSku.Split(new[] { sku }, StringSplitOptions.RemoveEmptyEntries);
+
+            if (skuParts.Length == 0) {
+                return 2;
+            }
+
+            return Int32.TryParse(skuParts[0].TrimStart('-'), out v) ?
+                (int?)++v :
+                null;
+        }
+
+        private string GenerateUniqueSku(ProductPart part, IEnumerable<string> existingSkus) {
+            if (existingSkus == null || !existingSkus.Contains(part.Sku)) {
+                return part.Sku;
+            }
+
+            int? version = existingSkus
+                .Select(s => GetSkuVersion(part.Sku, s))
+                .OrderBy(i => i).LastOrDefault();
+
+            return version != null ?
+                string.Format("{0}-{!}", part.Sku, version) :
+                part.Sku;
+        }
+
+        private IEnumerable<ProductPart> GetSimilarSkus(string sku) {
+            return _contentManager.Query<ProductPart, ProductPartRecord>()
+                .Where(part => part.Sku != null && part.Sku.StartsWith(sku))
+                .List();
+        }
+
+        public bool ProcessSku(ProductPart part) {
+            var similarSkuParts = GetSimilarSkus(part.Sku);
+            //dont include the part we are processing
+            similarSkuParts = similarSkuParts.Where(pp => pp.Id != part.Id);
+            //consider exceptions to uniqueness
+            if (_SKUUniquenessExceptionProviders.Any()) {
+                var exceptionIds = _SKUUniquenessExceptionProviders.SelectMany(p => p.GetIdsOfValidSKUDuplicates(part));
+                similarSkuParts = similarSkuParts.Where(pp => !exceptionIds.Contains(pp.Id));
+            }
+
+            if (similarSkuParts.Any()) {
+                var oldSku = part.Sku;
+                part.Sku = GenerateUniqueSku(part, similarSkuParts.Select(p => p.Sku));
+
+                return part.Sku == oldSku;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Services/SKUGenerationServices.cs
+++ b/Services/SKUGenerationServices.cs
@@ -97,7 +97,7 @@ namespace Nwazet.Commerce.Services {
         public bool ProcessSku(ProductPart part) {
             var similarSkuParts = GetSimilarSkus(part.Sku);
             //dont include the part we are processing
-            similarSkuParts = similarSkuParts.Where(pp => pp.Id != part.Id);
+            similarSkuParts = similarSkuParts.Where(pp => pp.ContentItem.Id != part.ContentItem.Id);
             //consider exceptions to uniqueness
             if (_SKUUniquenessExceptionProviders.Any()) {
                 var exceptionIds = _SKUUniquenessExceptionProviders.SelectMany(p => p.GetIdsOfValidSKUDuplicates(part));

--- a/Services/SKUGenerationServices.cs
+++ b/Services/SKUGenerationServices.cs
@@ -18,6 +18,8 @@ namespace Nwazet.Commerce.Services {
         private readonly IEnumerable<ISKUUniquenessExceptionProvider> _SKUUniquenessExceptionProviders;
         private readonly IContentManager _contentManager;
 
+        public string DefaultSkuPattern { get { return "SKU-{Content.Slug}"; } }
+
         public SKUGenerationServices(IOrchardServices orchardServices,
             ITokenizer tokenizer,
             IEnumerable<ISKUUniquenessExceptionProvider> SKUUniquenessExceptionProviders,
@@ -50,7 +52,7 @@ namespace Nwazet.Commerce.Services {
             }
             if (string.IsNullOrWhiteSpace(pattern)) {
                 //use a default pattern
-                pattern = "SKU-{Content.Id}";
+                pattern = DefaultSkuPattern;
             }
             var sku = _tokenizer.Replace(pattern, 
                 BuildTokenContext(part.ContentItem), 

--- a/ViewModels/AdancedSKUsSiteSettingsViewModel.cs
+++ b/ViewModels/AdancedSKUsSiteSettingsViewModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orchard.Environment.Extensions;
+
+namespace Nwazet.Commerce.ViewModels {
+    [OrchardFeature("Nwazet.AdvancedSKUManagement")]
+    public class AdancedSKUsSiteSettingsViewModel {
+        public bool RequireUniqueSKU { get; set; }
+    }
+}

--- a/ViewModels/AdancedSKUsSiteSettingsViewModel.cs
+++ b/ViewModels/AdancedSKUsSiteSettingsViewModel.cs
@@ -9,5 +9,8 @@ namespace Nwazet.Commerce.ViewModels {
     [OrchardFeature("Nwazet.AdvancedSKUManagement")]
     public class AdancedSKUsSiteSettingsViewModel {
         public bool RequireUniqueSKU { get; set; }
+        public bool GenerateSKUAutomatically { get; set; }
+        public string SKUPattern { get; set; }
+        public bool AllowCustomPattern { get; set; }
     }
 }

--- a/ViewModels/AdvancedSKUProductEditorViewModel.cs
+++ b/ViewModels/AdvancedSKUProductEditorViewModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nwazet.Commerce.Models;
+
+namespace Nwazet.Commerce.ViewModels {
+    public class AdvancedSKUProductEditorViewModel {
+        public ProductPart Product { get; set; }
+        public string CurrentSku { get; set; }
+        public AdvancedSKUsSiteSettingPart Settings { get; set; }
+        public string SkuPattern { get; set; }
+    }
+}

--- a/Views/ECommerceSettingsAdmin/Index.cshtml
+++ b/Views/ECommerceSettingsAdmin/Index.cshtml
@@ -1,0 +1,12 @@
+﻿﻿@using Orchard.ContentManagement
+@{
+    Layout.Title = T("Settings").ToString();
+}
+
+@using (Html.BeginFormAntiForgeryPost()) {
+    @Html.ValidationSummary()
+    @Display(Model.Content)
+    <fieldset>
+        <button class="primaryAction" type="submit">@T("Save")</button>
+    </fieldset>
+}

--- a/Views/EditorTemplates/Parts/AdvancedSKUProduct.cshtml
+++ b/Views/EditorTemplates/Parts/AdvancedSKUProduct.cshtml
@@ -4,32 +4,38 @@
 
 @{
     string skuHtml = "";
-
-    string ToReplace1 = "<label class=\\\"sub\\\" for=\\\"" + Html.IdFor(m => m.Product.Sku) + "\\\">" + T("Sku") + "</label><br>";
-    string ToReplace2 = Html.TextBoxFor(m => m.Product.Sku, new { @class = "text" }) + "<br>";
 }
 @if (Model.Settings.AllowCustomPattern) {
     //allow editing the sku
     skuHtml = "<label class=\\\"sub\\\" for=\\\"" + Html.IdFor(m => m.CurrentSku) + "\\\">" + T("Sku") + "</label><br />" +
-        Html.TextBoxFor(m => m.CurrentSku, new { @class = "text" }) + "<br />" +
+        Html.TextBoxFor(m => m.CurrentSku, new { @class = "text" }).ToString().Replace("\"", "\\\"") + "<br />" +
         "<span class=\\\"hint\\\">" + T("Save the current item and leave the input empty to have the sku automatically generated using the pattern {0}", Model.SkuPattern) + "</span>";
 }
 else {
-    //don't allow editing the sku
-    if (string.IsNullOrWhiteSpace(Model.Product.Sku)) {
-        skuHtml = "<span class=\\\"\\\">" + T("Save the current item to have the sku automatically generated using the pattern {0}", Model.SkuPattern) + "</span>";
+    if (Model.Settings.GenerateSKUAutomatically) { //don't allow editing the sku
+        if (string.IsNullOrWhiteSpace(Model.Product.Sku)) {
+            skuHtml = "<span class=\\\"\\\">" + T("Save the current item to have the sku automatically generated using the pattern {0}", Model.SkuPattern) + "</span>";
+        }
+        else {
+            skuHtml = "<span><b>Sku:</b> " + Model.Product.Sku + "</span>";
+        }
     }
     else {
-        skuHtml = "<span><b>Sku:</b> " + Model.Product.Sku + "</span>";
+        //allow editing the sku
+        skuHtml = "<label class=\\\"sub\\\" for=\\\"" + Html.IdFor(m => m.CurrentSku) + "\\\">" + T("Sku") + "</label><br />" +
+            Html.TextBoxFor(m => m.CurrentSku, new { @class = "text" }).ToString().Replace("\"", "\\\"") + "<br />";
     }
 }
 
 @using (Script.Foot()) {
     <script type="text/javascript">
         //replace the sku portion of the usual view with what we have here
-        (function () {
-            document.body.innerHTML.replace("@Html.Raw(ToReplace1)", "");
-            document.body.innerHTML.replace("@Html.Raw(ToReplace2.Replace("\"","\\\""))", "@Html.Raw(skuHtml)");
+        $(function () {
+            var tb = $("#@Html.IdFor(m => m.Product.Sku)"); //input where in the normal view we write the sku
+            var lbl = $("[for='@Html.IdFor(m => m.Product.Sku)'"); //corresponding label
+            tb.after("@Html.Raw(skuHtml)");
+            tb.remove();
+            lbl.remove();
         })
     </script>
 }

--- a/Views/EditorTemplates/Parts/AdvancedSKUProduct.cshtml
+++ b/Views/EditorTemplates/Parts/AdvancedSKUProduct.cshtml
@@ -1,0 +1,35 @@
+﻿@model Nwazet.Commerce.ViewModels.AdvancedSKUProductEditorViewModel
+
+@Html.HiddenFor(m => m.Product.Sku)
+
+@{
+    string skuHtml = "";
+
+    string ToReplace1 = "<label class=\\\"sub\\\" for=\\\"" + Html.IdFor(m => m.Product.Sku) + "\\\">" + T("Sku") + "</label><br>";
+    string ToReplace2 = Html.TextBoxFor(m => m.Product.Sku, new { @class = "text" }) + "<br>";
+}
+@if (Model.Settings.AllowCustomPattern) {
+    //allow editing the sku
+    skuHtml = "<label class=\\\"sub\\\" for=\\\"" + Html.IdFor(m => m.CurrentSku) + "\\\">" + T("Sku") + "</label><br />" +
+        Html.TextBoxFor(m => m.CurrentSku, new { @class = "text" }) + "<br />" +
+        "<span class=\\\"hint\\\">" + T("Save the current item and leave the input empty to have the sku automatically generated using the pattern {0}", Model.SkuPattern) + "</span>";
+}
+else {
+    //don't allow editing the sku
+    if (string.IsNullOrWhiteSpace(Model.Product.Sku)) {
+        skuHtml = "<span class=\\\"\\\">" + T("Save the current item to have the sku automatically generated using the pattern {0}", Model.SkuPattern) + "</span>";
+    }
+    else {
+        skuHtml = "<span><b>Sku:</b> " + Model.Product.Sku + "</span>";
+    }
+}
+
+@using (Script.Foot()) {
+    <script type="text/javascript">
+        //replace the sku portion of the usual view with what we have here
+        (function () {
+            document.body.innerHTML.replace("@Html.Raw(ToReplace1)", "");
+            document.body.innerHTML.replace("@Html.Raw(ToReplace2.Replace("\"","\\\""))", "@Html.Raw(skuHtml)");
+        })
+    </script>
+}

--- a/Views/EditorTemplates/Parts/AdvancedSKUProduct.cshtml
+++ b/Views/EditorTemplates/Parts/AdvancedSKUProduct.cshtml
@@ -13,15 +13,15 @@
 }
 else {
     if (Model.Settings.GenerateSKUAutomatically) { //don't allow editing the sku
-        if (string.IsNullOrWhiteSpace(Model.Product.Sku)) {
+        if (string.IsNullOrWhiteSpace(Model.CurrentSku)) {
             skuHtml = "<span class=\\\"\\\">" + T("Save the current item to have the sku automatically generated using the pattern {0}", Model.SkuPattern) + "</span>";
         }
         else {
-            skuHtml = "<span><b>Sku:</b> " + Model.Product.Sku + "</span>";
+            skuHtml = "<span><b>Sku:</b> " + Model.CurrentSku + "</span>";
         }
     }
     else {
-        //allow editing the sku
+        //allow editing the sku (we are not generating the sku automatically)
         skuHtml = "<label class=\\\"sub\\\" for=\\\"" + Html.IdFor(m => m.CurrentSku) + "\\\">" + T("Sku") + "</label><br />" +
             Html.TextBoxFor(m => m.CurrentSku, new { @class = "text" }).ToString().Replace("\"", "\\\"") + "<br />";
     }

--- a/Views/EditorTemplates/SiteSettings/AdvancedSKUs.cshtml
+++ b/Views/EditorTemplates/SiteSettings/AdvancedSKUs.cshtml
@@ -1,0 +1,8 @@
+﻿@using Nwazet.Commerce.Services
+@model Nwazet.Commerce.ViewModels.AdancedSKUsSiteSettingsViewModel
+
+<fieldset>
+    @Html.CheckBoxFor(m => m.RequireUniqueSKU)
+    <label class="forcheckbox" for="@Html.IdFor(m => m.RequireUniqueSKU)">@T("Ensure unique SKUs")</label>
+    <div class="hint">@T("Define whether we should enforce uniqueness checks for product SKUs.")</div>
+</fieldset>

--- a/Views/EditorTemplates/SiteSettings/AdvancedSKUs.cshtml
+++ b/Views/EditorTemplates/SiteSettings/AdvancedSKUs.cshtml
@@ -3,6 +3,17 @@
 
 <fieldset>
     @Html.CheckBoxFor(m => m.RequireUniqueSKU)
-    <label class="forcheckbox" for="@Html.IdFor(m => m.RequireUniqueSKU)">@T("Ensure unique SKUs")</label>
+    <label class="forcheckbox" for="@Html.FieldIdFor(m => m.RequireUniqueSKU)">@T("Ensure unique SKUs")</label>
     <div class="hint">@T("Define whether we should enforce uniqueness checks for product SKUs.")</div>
+    @Html.CheckBoxFor(m => m.GenerateSKUAutomatically)
+    <label class="forcheckbox" for="@Html.FieldIdFor(m => m.GenerateSKUAutomatically)">@T("Enable automatic SKU generation")</label>
+    <div class="hint">@T("The automatic generation of SKUs happens with a process similar to the one used for AutoRoute.")</div>
+    <div data-controllerid="@Html.FieldIdFor(m => m.GenerateSKUAutomatically)">
+        <label for="@Html.FieldIdFor(m => m.SKUPattern)">@T("Pattern")</label>
+        @Html.TextBoxFor(m => m.SKUPattern, new { @class = "tokenized text" })
+        <span class="hint">@T("The definition of the pattern")</span>
+        @Html.CheckBoxFor(m => m.AllowCustomPattern)
+        <label class="forcheckbox" for="@Html.FieldIdFor(m => m.AllowCustomPattern)">@T("Allow custom patterns")</label>
+        <div class="hint">@T("Allow the user to change the pattern on each item.")</div>
+    </div>
 </fieldset>

--- a/placement.info
+++ b/placement.info
@@ -7,6 +7,7 @@
   <Place Parts_Usps_Settings="Content:5"/>
   <Place Parts_Stripe_Settings="Content:5"/>
   <Place Parts_Product_Settings="Content:5"/>
+  <Place SiteSettings_AdvancedSKUs="Content:5"/>
   <Place Parts_UspsShippingMethod_Edit="Content:2"/>
   <Place UspsShippingTestForm="Content:6"/>
   <Place Parts_WeightBasedShippingMethod_Edit="Content:2"/>

--- a/placement.info
+++ b/placement.info
@@ -1,5 +1,6 @@
 ﻿<Placement>
   <Place Parts_Product_Edit="Content:3.1"/>
+  <Place Part_Product_SKUEdit="Content:3.1"/>
   <Place Parts_Product="Content:3.1"/>
   <Place Parts_Product_PriceTiers="Content:3.2"/>
   <Place Parts_Product_AddButton="Content:3.3"/>


### PR DESCRIPTION
This implements the first stage of enhancements discussed in #101.
Pasting from there:

>  sets up a feature that has:
>  
>   - A setting to enforce checks on the uniqueness of SKUs.
>   - A setting enabling automatic generation of SKUs:
>     - The generation works similarly to Autoroute, but it is based on a site setting, rather than a type setting.
>     - The default pattern is `"{SKU-{Content.Id}"`

With the difference that the default pattern used is `SKU-{Content.Slug}`

The settings for this go in a menu under `Commerce -> Settings`


