### PR TITLE
fix to #128

### DIFF
--- a/Views/Parts/Product.AddToCartFromWishlist.cshtml
+++ b/Views/Parts/Product.AddToCartFromWishlist.cshtml
@@ -12,7 +12,6 @@
                     new { area = "Nwazet.Commerce" }),
         FormMethod.Post,
         new Dictionary<string, object> {
-            {"class", "addtocart"},
             {"enctype", "multipart/form-data"}
         })) {
     <div class="wishlist-addtocart-button">


### PR DESCRIPTION
Removing the css class from the form in the "Add to cart" buttons of wishlists makes it so that the schopping cart scripts are not called, hence fixing the bug from #128 