### PR TITLE
Update tests

### DIFF
--- a/Models/ZipCodeTaxPart.cs
+++ b/Models/ZipCodeTaxPart.cs
@@ -31,7 +31,7 @@ namespace Nwazet.Commerce.Models {
             var rates = new Dictionary<string, decimal>();
             string[] rateLines = Rates.Split(new string[] { "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
             foreach(var rateLine in rateLines) {
-                var rateSplit = rateLine.Split(new string[] { ",", "\t" }, StringSplitOptions.None);
+                var rateSplit = rateLine.Split(new string[] { ",", "\t" }, 2, StringSplitOptions.None);
                 rates.Add(rateSplit[0], Convert.ToDecimal(rateSplit[1]));
             }
 

--- a/Nwazet.Commerce.Tests/Helpers/ShippingHelpers.cs
+++ b/Nwazet.Commerce.Tests/Helpers/ShippingHelpers.cs
@@ -8,7 +8,7 @@ using Orchard;
 namespace Nwazet.Commerce.Tests.Helpers {
     public class ShippingHelpers {
         public static WeightBasedShippingMethodPart BuildWeightBasedShippingMethod(
-            double price,
+            decimal price,
             double minimumWeight = 0,
             double maximumWeight = double.PositiveInfinity) {
 
@@ -22,7 +22,7 @@ namespace Nwazet.Commerce.Tests.Helpers {
         }
 
         public static SizeBasedShippingMethodPart BuildSizeBasedShippingMethod(
-            double price,
+            decimal price,
             string size = null,
             int priority = 0) {
 
@@ -55,7 +55,7 @@ namespace Nwazet.Commerce.Tests.Helpers {
 
         public static IWorkContextAccessor GetUspsWorkContextAccessor(string originZip,
             bool commercialPrices,
-            bool commercialPlusPrices, double price = 10) {
+            bool commercialPlusPrices, decimal price = 10) {
             return new WorkContextAccessorStub(new Dictionary<Type, object> {
                 {
                     typeof (IUspsService),

--- a/Nwazet.Commerce.Tests/Helpers/ShoppingCartHelpers.cs
+++ b/Nwazet.Commerce.Tests/Helpers/ShoppingCartHelpers.cs
@@ -12,7 +12,7 @@ using Orchard.UI.Notify;
 
 namespace Nwazet.Commerce.Tests.Helpers {
     public class ShoppingCartHelpers {
-        private static readonly double[] Prices = { 10, 1.5, 20 };
+        private static readonly decimal[] Prices = { 10, 1.5M, 20 };
         private static readonly int[] Quantities = { 3, 6, 5 };
         private static readonly string[] Paths = {"foo/bar", "bar/baz", "foo/baz/glop"};
 
@@ -75,7 +75,7 @@ namespace Nwazet.Commerce.Tests.Helpers {
             return cart;
         }
 
-        public static double CartPriceOf(IProduct product, IEnumerable<ShoppingCartQuantityProduct> quantities) {
+        public static decimal CartPriceOf(IProduct product, IEnumerable<ShoppingCartQuantityProduct> quantities) {
             return quantities.First(i => i.Product == product).Price;
         }
     }

--- a/Nwazet.Commerce.Tests/PriceProviderTests.cs
+++ b/Nwazet.Commerce.Tests/PriceProviderTests.cs
@@ -30,7 +30,7 @@ namespace Nwazet.Commerce.Tests {
             };
             var cart = ShoppingCartHelpers.PrepareCart(new[] {discount});
 
-            CheckDiscount(cart, 0.7, discount.Comment);
+            CheckDiscount(cart, 0.7M, discount.Comment);
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace Nwazet.Commerce.Tests {
             };
             var cart = ShoppingCartHelpers.PrepareCart(new[] { mediocreDiscount, bestDiscount, betterDiscount });
 
-            CheckDiscount(cart, 0.8, bestDiscount.Comment);
+            CheckDiscount(cart, 0.8M, bestDiscount.Comment);
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace Nwazet.Commerce.Tests {
             };
             var cart = ShoppingCartHelpers.PrepareCart(new[] { currentDiscount });
 
-            CheckDiscount(cart, 0.95, currentDiscount.Comment);
+            CheckDiscount(cart, 0.95M, currentDiscount.Comment);
         }
 
         [Test]
@@ -113,7 +113,7 @@ namespace Nwazet.Commerce.Tests {
             };
             var cart = ShoppingCartHelpers.PrepareCart(new[] { wideEnoughDiscount });
 
-            CheckDiscount(cart, 0.9, wideEnoughDiscount.Comment);
+            CheckDiscount(cart, 0.9M, wideEnoughDiscount.Comment);
         }
 
         [Test]
@@ -126,7 +126,7 @@ namespace Nwazet.Commerce.Tests {
             };
             var cart = ShoppingCartHelpers.PrepareCart(new[] { selectiveDiscount });
 
-            CheckDiscounts(cart, new[] { 1, 0.9, 0.9 }, new[] { "", selectiveDiscount.Comment, selectiveDiscount.Comment });
+            CheckDiscounts(cart, new[] { 1, 0.9M, 0.9M }, new[] { "", selectiveDiscount.Comment, selectiveDiscount.Comment });
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace Nwazet.Commerce.Tests {
             };
             var cart = ShoppingCartHelpers.PrepareCart(new[] { patternDiscount });
 
-            CheckDiscounts(cart, new[] { 0.9, 1, 0.9 }, new[] { patternDiscount.Comment, "", patternDiscount.Comment });
+            CheckDiscounts(cart, new[] { 0.9M, 1, 0.9M }, new[] { patternDiscount.Comment, "", patternDiscount.Comment });
         }
 
         [Test]
@@ -150,7 +150,7 @@ namespace Nwazet.Commerce.Tests {
             };
             var cart = ShoppingCartHelpers.PrepareCart(new[] { patternDiscount });
 
-            CheckDiscounts(cart, new[] { 1, 0.9, 1 }, new[] { "", patternDiscount.Comment, "" });
+            CheckDiscounts(cart, new[] { 1, 0.9M, 1 }, new[] { "", patternDiscount.Comment, "" });
         }
 
         [Test]
@@ -163,7 +163,7 @@ namespace Nwazet.Commerce.Tests {
             };
             var cart = ShoppingCartHelpers.PrepareCart(new[] { patternDiscount });
 
-            CheckDiscounts(cart, new[] { 0.9, 1, 1 }, new[] { patternDiscount.Comment, "", "" });
+            CheckDiscounts(cart, new[] { 0.9M, 1, 1 }, new[] { patternDiscount.Comment, "", "" });
         }
 
         [Test]
@@ -187,7 +187,7 @@ namespace Nwazet.Commerce.Tests {
             };
             var cart = ShoppingCartHelpers.PrepareCart(new[] { roleDiscount });
 
-            CheckDiscount(cart, 0.9, roleDiscount.Comment);
+            CheckDiscount(cart, 0.9M, roleDiscount.Comment);
         }
 
         [Test]
@@ -198,17 +198,17 @@ namespace Nwazet.Commerce.Tests {
             };
             var cart = ShoppingCartHelpers.PrepareCart(new[] { absoluteDiscount });
 
-            CheckDiscounts(cart, new[] {0, 0, 0.5}, new[] {absoluteDiscount.Comment, absoluteDiscount.Comment, absoluteDiscount.Comment});
+            CheckDiscounts(cart, new[] {0, 0, 0.5M}, new[] {absoluteDiscount.Comment, absoluteDiscount.Comment, absoluteDiscount.Comment});
         }
 
         [Test]
         public void ProductDiscountApplies() {
             var cart = ShoppingCartHelpers.PrepareCart(new DiscountStub[] {}, applyProductDiscounts: true);
 
-            CheckDiscounts(cart, new[] { 1, 1, 0.5 }, new[] { "", "", "" });
+            CheckDiscounts(cart, new[] { 1, 1, 0.5M }, new[] { "", "", "" });
         }
 
-        private static void CheckDiscount(IShoppingCart cart, double discountRate, string comment) {
+        private static void CheckDiscount(IShoppingCart cart, decimal discountRate, string comment) {
             const double epsilon = 0.001;
             var expectedSubTotal = Math.Round(ShoppingCartHelpers.OriginalQuantities.Sum(q => q.Quantity * Math.Round(q.Product.Price * discountRate, 2)), 2);
             Assert.That(Math.Abs(cart.Subtotal() - expectedSubTotal), Is.LessThan(epsilon));
@@ -221,11 +221,11 @@ namespace Nwazet.Commerce.Tests {
             }
         }
 
-        private static void CheckDiscounts(IShoppingCart cart, double[] discountRates, string[] comments) {
+        private static void CheckDiscounts(IShoppingCart cart, decimal[] discountRates, string[] comments) {
             const double epsilon = 0.001;
             var cartContents = cart.GetProducts().ToList();
             var i = 0;
-            var expectedSubTotal = 0.0;
+            var expectedSubTotal = 0.0M;
             foreach (var shoppingCartQuantityProduct in cartContents) {
                 var discountedPrice = Math.Round(shoppingCartQuantityProduct.Product.Price*discountRates[i], 2);
                 Assert.That(

--- a/Nwazet.Commerce.Tests/PriceServiceTieredPricingTests.cs
+++ b/Nwazet.Commerce.Tests/PriceServiceTieredPricingTests.cs
@@ -60,7 +60,7 @@ namespace Nwazet.Commerce.Tests {
         public void AbsolutePriceIsUsedIfBothAbsoluteAndPercentageExist() {
             var cart = PrepareCart(WorkContextAccessorSiteWideDisabledOverrideEnabled);
             cart.Add(5, 11);
-            CheckCart(cart, 97.9);
+            CheckCart(cart, 97.9M);
         }
 
         [Test]
@@ -138,23 +138,23 @@ namespace Nwazet.Commerce.Tests {
             new ProductStub(1) {Price = 10, 
                                 OverrideTieredPricing = true, 
                                 PriceTiers = new List<PriceTier> {
-                                    new PriceTier { Quantity = 10, Price = 9.0 },
-                                    new PriceTier { Quantity = 50, Price = 8.0 },
-                                    new PriceTier { Quantity = 100, Price = 5.0 }
+                                    new PriceTier { Quantity = 10, Price = 9.0M },
+                                    new PriceTier { Quantity = 50, Price = 8.0M },
+                                    new PriceTier { Quantity = 100, Price = 5.0M }
                                 }},
             new ProductStub(2) {Price = 10, 
                                 OverrideTieredPricing = true, 
                                 PriceTiers = new List<PriceTier> {
-                                    new PriceTier { Quantity = 5, Price = 9.0 },
-                                    new PriceTier { Quantity = 10, Price = 8.0 },
-                                    new PriceTier { Quantity = 15, Price = 7.0 }
+                                    new PriceTier { Quantity = 5, Price = 9.0M },
+                                    new PriceTier { Quantity = 10, Price = 8.0M },
+                                    new PriceTier { Quantity = 15, Price = 7.0M }
                                 }},
             new ProductStub(3) {Price = 10, 
                                 OverrideTieredPricing = false, 
                                 PriceTiers = new List<PriceTier> {
-                                    new PriceTier { Quantity = 10, Price = 9.0 },
-                                    new PriceTier { Quantity = 50, Price = 8.0 },
-                                    new PriceTier { Quantity = 100, Price = 5.0 }
+                                    new PriceTier { Quantity = 10, Price = 9.0M },
+                                    new PriceTier { Quantity = 50, Price = 8.0M },
+                                    new PriceTier { Quantity = 100, Price = 5.0M }
                                 }},
             new ProductStub(4) {Price = 10, 
                                 OverrideTieredPricing = true, 
@@ -166,7 +166,7 @@ namespace Nwazet.Commerce.Tests {
             new ProductStub(5) {Price = 10, 
                                 OverrideTieredPricing = true, 
                                 PriceTiers = new List<PriceTier> {
-                                    new PriceTier { Quantity = 10, Price = 8.9, PricePercent = 90 }
+                                    new PriceTier { Quantity = 10, Price = 8.9M, PricePercent = 90 }
                                 }},
             new ProductStub(6) {Price = 10, 
                                 OverrideTieredPricing = false, 
@@ -189,7 +189,7 @@ namespace Nwazet.Commerce.Tests {
             return cart;
         }
 
-        private static void CheckCart(IShoppingCart cart, double expectedSubTotal) {
+        private static void CheckCart(IShoppingCart cart, decimal expectedSubTotal) {
             const double epsilon = 0.001;
             Assert.That(Math.Abs(cart.Subtotal() - expectedSubTotal), Is.LessThan(epsilon));
         }

--- a/Nwazet.Commerce.Tests/ProductAttributePricingTests.cs
+++ b/Nwazet.Commerce.Tests/ProductAttributePricingTests.cs
@@ -116,7 +116,7 @@ namespace Nwazet.Commerce.Tests {
             return cart;
         }
 
-        private static void CheckCart(IShoppingCart cart, double expectedSubTotal) {
+        private static void CheckCart(IShoppingCart cart, decimal expectedSubTotal) {
             const double epsilon = 0.001;
             Assert.That(Math.Abs(cart.Subtotal() - expectedSubTotal), Is.LessThan(epsilon));
         }

--- a/Nwazet.Commerce.Tests/ProductAttributeTests.cs
+++ b/Nwazet.Commerce.Tests/ProductAttributeTests.cs
@@ -237,7 +237,7 @@ namespace Nwazet.Commerce.Tests {
 
         private static readonly ProductStub[] Products = {
             new ProductStub(1, new[] {10, 11}) {Price = 10},
-            new ProductStub(2, new int[0]) {Price = 1.5},
+            new ProductStub(2, new int[0]) {Price = 1.5M},
             new ProductStub(3, new[] {11}) {Price = 20},
             new ProductStub(4, new int[0]) {Price = 15},
             new ProductStub(5, new[] {10, 11}) {Price = 27} 

--- a/Nwazet.Commerce.Tests/Stubs/ProductStub.cs
+++ b/Nwazet.Commerce.Tests/Stubs/ProductStub.cs
@@ -6,7 +6,7 @@ using Orchard.ContentManagement.FieldStorage.InfosetStorage;
 namespace Nwazet.Commerce.Tests.Stubs {
     public class ProductStub : ProductPart {
         public ProductStub(int id = -1, IEnumerable<int> attributeIds = null) {
-            ContentHelpers.PreparePart<ProductPart, ProductPartRecord>(this, "Product", id);
+            ContentHelpers.PreparePart<ProductPart, ProductPartVersionRecord>(this, "Product", id);
             ContentItem.Weld(new InfosetPart());
             ShippingCost = -1;
             if (attributeIds != null) {

--- a/Nwazet.Commerce.Tests/Stubs/UspsServiceStub.cs
+++ b/Nwazet.Commerce.Tests/Stubs/UspsServiceStub.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Nwazet.Commerce.Models;
 using Nwazet.Commerce.Services;
 using Nwazet.Commerce.Tests.Helpers;
@@ -9,9 +10,9 @@ namespace Nwazet.Commerce.Tests.Stubs {
         private readonly string _originZip;
         private readonly bool _commercialPrices;
         private readonly bool _commercialPlusPrices;
-        private readonly double _price;
+        private readonly decimal _price;
 
-        public UspsServiceStub(string uspsUserId, string originZip, bool commercialPrices, bool commercialPlusPrices, double price = 10) {
+        public UspsServiceStub(string uspsUserId, string originZip, bool commercialPrices, bool commercialPlusPrices, decimal price = 10) {
             _uspsUserId = uspsUserId;
             _originZip = originZip;
             _commercialPrices = commercialPrices;
@@ -37,7 +38,7 @@ namespace Nwazet.Commerce.Tests.Stubs {
             return settings;
         }
 
-        public IEnumerable<ShippingOption> Prices(string userId, double weightInOunces, double valueOfContents, string container,
+        public IEnumerable<ShippingOption> Prices(string userId, double weightInOunces, decimal valueOfContents, string container,
                                   string serviceNameValidationExpression, string serviceNameExclusionExpression, string country,
                                   int lengthInInches, int widthInInches, int heightInInches, string originZip, string destinationZip,
                                   bool commercialPrices, bool commercialPlusPrices, bool registeredMail, bool insurance,

--- a/Nwazet.Commerce.Tests/TaxByZipTests.cs
+++ b/Nwazet.Commerce.Tests/TaxByZipTests.cs
@@ -4,13 +4,48 @@ using Nwazet.Commerce.Models;
 using Nwazet.Commerce.Services;
 using Nwazet.Commerce.Tests.Helpers;
 using System;
+using System.Linq;
 
 namespace Nwazet.Commerce.Tests
 {
     class TaxByZipTests
     {
-        private const string CsvRates = "52411,.07\r\n52627,.05\r\n52405,.1\r\n52412,.08";
-        private const string TabRates = "52411\t.07\n52627\t.05\n52405\t.1\n52412\t.08";
+        private string CsvRates {
+            get {
+                return "52411," + (.07M).ToString() +
+                    "\r\n52627," + (.05M).ToString() + 
+                    "\r\n52405," + (.1M).ToString() + 
+                    "\r\n52412," + (.08M).ToString();
+            }
+        }
+        private string TabRates {
+            get {
+                return "52411\t" + (.07M).ToString() + 
+                    "\n52627\t" + (.05M).ToString() + 
+                    "\n52405\t" + (.1M).ToString() + 
+                    "\n52412\t" + (.08M).ToString();
+            }
+        }
+
+        [Test]
+        public void CsvRatesAreParsedCorrectly() {
+            var csvZipTax = new ZipCodeTaxPart();
+            ContentHelpers.PreparePart(csvZipTax, "Tax");
+            csvZipTax.Rates = CsvRates;
+
+            var Rates = csvZipTax.GetRates();
+            var rKeys = Rates.Keys.ToArray();
+            var rValues = Rates.Values.ToArray();
+            Assert.That(Rates.Count, Is.EqualTo(4));
+            Assert.That(rKeys[0], Is.EqualTo("52411"));
+            Assert.That(rValues[0], Is.EqualTo(.07M));
+            Assert.That(rKeys[1], Is.EqualTo("52627"));
+            Assert.That(rValues[1], Is.EqualTo(.05M));
+            Assert.That(rKeys[2], Is.EqualTo("52405"));
+            Assert.That(rValues[2], Is.EqualTo(.1M));
+            Assert.That(rKeys[3], Is.EqualTo("52412"));
+            Assert.That(rValues[3], Is.EqualTo(.08M));
+        }
 
         [Test]
         public void RightTaxAppliesToCsvRates() {
@@ -24,7 +59,27 @@ namespace Nwazet.Commerce.Tests
             cart.Country = "United States";
             cart.ZipCode = "52627";
 
-            CheckTaxes(cart.Taxes().Amount, 6.95);
+            CheckTaxes(cart.Taxes().Amount, 6.95M);
+        }
+
+        [Test]
+        public void TabRatesAreParsedCorrectly() {
+            var tabZipTax = new ZipCodeTaxPart();
+            ContentHelpers.PreparePart(tabZipTax, "Tax");
+            tabZipTax.Rates = TabRates;
+
+            var Rates = tabZipTax.GetRates();
+            var rKeys = Rates.Keys.ToArray();
+            var rValues = Rates.Values.ToArray();
+            Assert.That(Rates.Count, Is.EqualTo(4));
+            Assert.That(rKeys[0], Is.EqualTo("52411"));
+            Assert.That(rValues[0], Is.EqualTo(.07M));
+            Assert.That(rKeys[1], Is.EqualTo("52627"));
+            Assert.That(rValues[1], Is.EqualTo(.05M));
+            Assert.That(rKeys[2], Is.EqualTo("52405"));
+            Assert.That(rValues[2], Is.EqualTo(.1M));
+            Assert.That(rKeys[3], Is.EqualTo("52412"));
+            Assert.That(rValues[3], Is.EqualTo(.08M));
         }
 
         [Test]
@@ -39,7 +94,7 @@ namespace Nwazet.Commerce.Tests
             cart.Country = "United States";
             cart.ZipCode = "52412";
 
-            CheckTaxes(cart.Taxes().Amount, 11.12);
+            CheckTaxes(cart.Taxes().Amount, 11.12M);
         }
 
         [Test]
@@ -59,7 +114,7 @@ namespace Nwazet.Commerce.Tests
             Assert.IsNull(taxes.Name);
         }
 
-        private static void CheckTaxes(double actualTax, double expectedTax) {
+        private static void CheckTaxes(decimal actualTax, decimal expectedTax) {
             const double epsilon = 0.001;
             Assert.That(
                     Math.Abs(expectedTax - actualTax),

--- a/Nwazet.Commerce.Tests/TaxTests.cs
+++ b/Nwazet.Commerce.Tests/TaxTests.cs
@@ -108,13 +108,13 @@ namespace Nwazet.Commerce.Tests
         public void HigherPriorityWins() {
             var frenchTax1 = GetFrenchTax();
             frenchTax1.Priority = 1;
-            frenchTax1.Rate = 0.1;
+            frenchTax1.Rate = 0.1M;
             var anyCountryTax = GetAnyCountryTax();
             anyCountryTax.Priority = 2;
-            anyCountryTax.Rate = 0.2;
+            anyCountryTax.Rate = 0.2M;
             var frenchTax2 = GetFrenchTax();
             frenchTax2.Priority = 3;
-            frenchTax2.Rate = 0.3;
+            frenchTax2.Rate = 0.3M;
             var taxProvider = new FakeTaxProvider(new[] { frenchTax1, frenchTax2, anyCountryTax });
             var cart = ShoppingCartHelpers.PrepareCart(null, new[] { taxProvider });
             cart.Country = frenchTax1.Country;
@@ -146,7 +146,7 @@ namespace Nwazet.Commerce.Tests
         public void NoNegativeTax()
         {
             var frenchTax = GetFrenchTax();
-            frenchTax.Rate = -0.5;
+            frenchTax.Rate = -0.5M;
             var taxProvider = new FakeTaxProvider(new[] { frenchTax });
             var cart = ShoppingCartHelpers.PrepareCart(null, new[] { taxProvider });
 
@@ -163,7 +163,7 @@ namespace Nwazet.Commerce.Tests
             ContentHelpers.PreparePart<StateOrCountryTaxPart, StateOrCountryTaxPartRecord>(anyStateTax, "Tax");
             anyStateTax.Country = Country.UnitedStates;
             anyStateTax.State = "*";
-            anyStateTax.Rate = 0.05;
+            anyStateTax.Rate = 0.05M;
             return anyStateTax;
         }
 
@@ -172,7 +172,7 @@ namespace Nwazet.Commerce.Tests
             var anyCountryTax = new StateOrCountryTaxPart();
             ContentHelpers.PreparePart<StateOrCountryTaxPart, StateOrCountryTaxPartRecord>(anyCountryTax, "Tax");
             anyCountryTax.Country = "*";
-            anyCountryTax.Rate = 0.07;
+            anyCountryTax.Rate = 0.07M;
             return anyCountryTax;
         }
 
@@ -182,7 +182,7 @@ namespace Nwazet.Commerce.Tests
             ContentHelpers.PreparePart<StateOrCountryTaxPart, StateOrCountryTaxPartRecord>(oregonTax, "Tax");
             oregonTax.Country = Country.UnitedStates;
             oregonTax.State = "OR";
-            oregonTax.Rate = 0.15;
+            oregonTax.Rate = 0.15M;
             return oregonTax;
         }
 
@@ -191,7 +191,7 @@ namespace Nwazet.Commerce.Tests
             ContentHelpers.PreparePart<StateOrCountryTaxPart, StateOrCountryTaxPartRecord>(washingtonTax, "Tax");
             washingtonTax.Country = Country.UnitedStates;
             washingtonTax.State = "WA";
-            washingtonTax.Rate = 0.095;
+            washingtonTax.Rate = 0.095M;
             return washingtonTax;
         }
 
@@ -199,7 +199,7 @@ namespace Nwazet.Commerce.Tests
             var frenchTax = new StateOrCountryTaxPart();
             ContentHelpers.PreparePart<StateOrCountryTaxPart, StateOrCountryTaxPartRecord>(frenchTax, "Tax");
             frenchTax.Country = "France";
-            frenchTax.Rate = 0.19;
+            frenchTax.Rate = 0.19M;
             return frenchTax;
         }
 
@@ -208,7 +208,7 @@ namespace Nwazet.Commerce.Tests
             var britishTax = new StateOrCountryTaxPart();
             ContentHelpers.PreparePart<StateOrCountryTaxPart, StateOrCountryTaxPartRecord>(britishTax, "Tax");
             britishTax.Country = "United Kingdom (Great Britain and Northern Ireland)";
-            britishTax.Rate = 0.15;
+            britishTax.Rate = 0.15M;
             return britishTax;
         }
 

--- a/Nwazet.Commerce.Tests/UspsServiceDomesticTests.cs
+++ b/Nwazet.Commerce.Tests/UspsServiceDomesticTests.cs
@@ -18,7 +18,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticRequestDocumentIsCorrectlyBuilt() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 5, 3, 2, "98052", "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", 5, 3, 2, "98052", "90220",
                 false, false, false, false, false);
 
             Assert.That(requestDocument.Name.LocalName, Is.EqualTo("RateV4Request"));
@@ -40,7 +40,7 @@ namespace Nwazet.Commerce.Tests {
             Assert.That(package.Element("Width").Value, Is.EqualTo("3"));
             Assert.That(package.Element("Height").Value, Is.EqualTo("2"));
             Assert.That(package.Element("Girth"), Is.Null);
-            Assert.That(package.Element("Value").Value, Is.EqualTo("1030.54"));
+            Assert.That(package.Element("Value").Value, Is.EqualTo((1030.54M).ToString()));
             Assert.That(package.Element("SortBy").Value, Is.EqualTo("PACKAGE"));
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
 
@@ -51,19 +51,19 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticRequestSmallPackageIsNotMachinable() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 5, 1, 3, "98052", "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", 5, 1, 3, "98052", "90220",
                 false, false, false, false, false);
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
 
             requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 6, 1, 2, "98052", "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", 6, 1, 2, "98052", "90220",
                 false, false, false, false, false);
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
 
             requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 6, 0, 3, "98052", "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", 6, 0, 3, "98052", "90220",
                 false, false, false, false, false);
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
@@ -72,17 +72,17 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticRequestLargePackageIsNotMachinable() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 28, 17, 17, "98052", "90220");
+                "Joe User", 45.3, 1030.54M, "Big Box", 28, 17, 17, "98052", "90220");
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
 
             requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 27, 18, 17, "98052", "90220");
+                "Joe User", 45.3, 1030.54M, "Big Box", 27, 18, 17, "98052", "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
 
             requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 27, 17, 18, "98052", "90220");
+                "Joe User", 45.3, 1030.54M, "Big Box", 27, 17, 18, "98052", "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
         }
@@ -90,7 +90,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticRequestLightPackageIsNotMachinable() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 5, 1030.54, "Big Box", 28, 17, 17, "98052", "90220");
+                "Joe User", 5, 1030.54M, "Big Box", 28, 17, 17, "98052", "90220");
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
         }
@@ -98,7 +98,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticRequestHeavyPackageIsNotMachinable() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 401, 1030.54, "Big Box", 28, 17, 17, "98052", "90220");
+                "Joe User", 401, 1030.54M, "Big Box", 28, 17, 17, "98052", "90220");
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
         }
@@ -106,27 +106,27 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticRequestMachinablePackageIsMachinable() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 27, 17, 17, "98052", "90220");
+                "Joe User", 45.3, 1030.54M, "Big Box", 27, 17, 17, "98052", "90220");
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("true"));
 
             requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 6, 1, 3, "98052", "90220");
+                "Joe User", 45.3, 1030.54M, "Big Box", 6, 1, 3, "98052", "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("true"));
 
             requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 10, 10, 10, "98052", "90220");
+                "Joe User", 45.3, 1030.54M, "Big Box", 10, 10, 10, "98052", "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("true"));
 
             requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 6, 1030.54, "Big Box", 10, 10, 10, "98052", "90220");
+                "Joe User", 6, 1030.54M, "Big Box", 10, 10, 10, "98052", "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("true"));
 
             requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 400, 1030.54, "Big Box", 10, 10, 10, "98052", "90220");
+                "Joe User", 400, 1030.54M, "Big Box", 10, 10, 10, "98052", "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("true"));
         }
@@ -134,17 +134,17 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticRequestLargePackageIsLarge() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 40, 1030.54, "Big Box", 13, 12, 12, "98052", "90220");
+                "Joe User", 40, 1030.54M, "Big Box", 13, 12, 12, "98052", "90220");
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Size").Value, Is.EqualTo("LARGE"));
 
             requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 40, 1030.54, "Big Box", 12, 13, 12, "98052", "90220");
+                "Joe User", 40, 1030.54M, "Big Box", 12, 13, 12, "98052", "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Size").Value, Is.EqualTo("LARGE"));
 
             requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 40, 1030.54, "Big Box", 12, 12, 13, "98052", "90220");
+                "Joe User", 40, 1030.54M, "Big Box", 12, 12, 13, "98052", "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Size").Value, Is.EqualTo("LARGE"));
         }
@@ -152,12 +152,12 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticRequestRegularPackageIsNotLarge() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 40, 1030.54, "Big Box", 12, 12, 12, "98052", "90220");
+                "Joe User", 40, 1030.54M, "Big Box", 12, 12, 12, "98052", "90220");
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Size").Value, Is.EqualTo("REGULAR"));
 
             requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 40, 1030.54, "Big Box", 5, 5, 5, "98052", "90220");
+                "Joe User", 40, 1030.54M, "Big Box", 5, 5, 5, "98052", "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Size").Value, Is.EqualTo("REGULAR"));
         }
@@ -165,7 +165,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticRegisteredMailIsExpressed() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 5, 3, 2, "98052", "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", 5, 3, 2, "98052", "90220",
                 true, false, false, false, false);
 
             var package = requestDocument.Element("Package");
@@ -177,7 +177,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticInsuranceIsExpressed() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 5, 3, 2, "98052", "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", 5, 3, 2, "98052", "90220",
                 false, true, false, false, false);
 
             var package = requestDocument.Element("Package");
@@ -189,7 +189,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticReturnReceiptIsExpressed() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 5, 3, 2, "98052", "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", 5, 3, 2, "98052", "90220",
                 false, false, true, false, false);
 
             var package = requestDocument.Element("Package");
@@ -201,7 +201,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticCertificateOfMailingIsExpressed() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 5, 3, 2, "98052", "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", 5, 3, 2, "98052", "90220",
                 false, false, false, true, false);
 
             var package = requestDocument.Element("Package");
@@ -213,7 +213,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticElectronicConfirmationIsExpressed() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 5, 3, 2, "98052", "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", 5, 3, 2, "98052", "90220",
                 false, false, false, false, true);
 
             var package = requestDocument.Element("Package");
@@ -225,7 +225,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void DomesticServicesAreExpressed() {
             var requestDocument = UspsService.BuildDomesticShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", 5, 3, 2, "98052", "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", 5, 3, 2, "98052", "90220",
                 true, true, true, true, true);
 
             var package = requestDocument.Element("Package");
@@ -243,26 +243,26 @@ namespace Nwazet.Commerce.Tests {
         public void DomesticServicePricesReturnsDomesticPrices() {
             var uspsService = BuildFakeUspsService();
             var prices = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "United States", 5, 3, 2, "98052", "90220", false, false,
                 false, false, false, false, false).ToList();
             Assert.That(prices.Count, Is.EqualTo(15));
             Assert.That(prices, new CollectionEquivalentConstraint(new[] {
-                new ShippingOption {Description = "First-Class Mail", Price = 1.06},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup>", Price = 24.85},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup>", Price = 18.35},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> Large Flat Rate Box", Price = 14.85},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> Medium Flat Rate Box", Price = 12.35},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> Small Flat Rate Box", Price = 5.8},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> Flat Rate Envelope", Price = 5.6},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> Legal Flat Rate Envelope", Price = 5.75},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> Padded Flat Rate Envelope", Price = 5.95},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> Gift Card Flat Rate Envelope", Price = 5.6},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> Small Flat Rate Envelope", Price = 5.6},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> Window Flat Rate Envelope", Price = 5.6},
-                new ShippingOption {Description = "Standard Post<sup>®</sup>", Price = 18.35},
-                new ShippingOption {Description = "Media Mail<sup>®</sup>", Price = 6.52},
-                new ShippingOption {Description = "Library Mail", Price = 6.21}
+                new ShippingOption {Description = "First-Class Mail", Price = 1.06M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup>", Price = 24.85M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup>", Price = 18.35M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> Large Flat Rate Box", Price = 14.85M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> Medium Flat Rate Box", Price = 12.35M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> Small Flat Rate Box", Price = 5.8M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> Flat Rate Envelope", Price = 5.6M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> Legal Flat Rate Envelope", Price = 5.75M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> Padded Flat Rate Envelope", Price = 5.95M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> Gift Card Flat Rate Envelope", Price = 5.6M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> Small Flat Rate Envelope", Price = 5.6M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> Window Flat Rate Envelope", Price = 5.6M},
+                new ShippingOption {Description = "Standard Post<sup>®</sup>", Price = 18.35M},
+                new ShippingOption {Description = "Media Mail<sup>®</sup>", Price = 6.52M},
+                new ShippingOption {Description = "Library Mail", Price = 6.21M}
             }).Using(new ShippingOption.ShippingOptionComparer()));
         }
 
@@ -270,14 +270,14 @@ namespace Nwazet.Commerce.Tests {
         public void DomesticServicePricesWithValidationExpressionSelectsMatchingMethods() {
             var uspsService = BuildFakeUspsService();
             var prices = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", "Box", null,
+                "Joe User", 45.3, 1030.54M, "Big Box", "Box", null,
                 "United States", 5, 3, 2, "98052", "90220", false, false,
                 false, false, false, false, false).ToList();
             Assert.That(prices.Count, Is.EqualTo(3));
             Assert.That(prices, new CollectionEquivalentConstraint(new[] {
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> Large Flat Rate Box", Price = 14.85},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> Medium Flat Rate Box", Price = 12.35},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> Small Flat Rate Box", Price = 5.8},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> Large Flat Rate Box", Price = 14.85M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> Medium Flat Rate Box", Price = 12.35M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> Small Flat Rate Box", Price = 5.8M},
             }).Using(new ShippingOption.ShippingOptionComparer()));
         }
 
@@ -285,15 +285,15 @@ namespace Nwazet.Commerce.Tests {
         public void DomesticServicePricesWithExclusionExpressionExcludesMatchingMethods() {
             var uspsService = BuildFakeUspsService();
             var prices = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, "Priority",
+                "Joe User", 45.3, 1030.54M, "Big Box", null, "Priority",
                 "United States", 5, 3, 2, "98052", "90220", false, false,
                 false, false, false, false, false).ToList();
             Assert.That(prices.Count, Is.EqualTo(4));
             Assert.That(prices, new CollectionEquivalentConstraint(new[] {
-                new ShippingOption {Description = "First-Class Mail", Price = 1.06},
-                new ShippingOption {Description = "Standard Post<sup>®</sup>", Price = 18.35},
-                new ShippingOption {Description = "Media Mail<sup>®</sup>", Price = 6.52},
-                new ShippingOption {Description = "Library Mail", Price = 6.21}
+                new ShippingOption {Description = "First-Class Mail", Price = 1.06M},
+                new ShippingOption {Description = "Standard Post<sup>®</sup>", Price = 18.35M},
+                new ShippingOption {Description = "Media Mail<sup>®</sup>", Price = 6.52M},
+                new ShippingOption {Description = "Library Mail", Price = 6.21M}
             }).Using(new ShippingOption.ShippingOptionComparer()));
         }
 
@@ -301,14 +301,14 @@ namespace Nwazet.Commerce.Tests {
         public void DomesticServicePricesWithExclusionAndValidationExpressionsYieldsTheRightMethods() {
             var uspsService = BuildFakeUspsService();
             var prices = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", "Mail", "Priority",
+                "Joe User", 45.3, 1030.54M, "Big Box", "Mail", "Priority",
                 "United States", 5, 3, 2, "98052", "90220", false, false,
                 false, false, false, false, false).ToList();
             Assert.That(prices.Count, Is.EqualTo(3));
             Assert.That(prices, new CollectionEquivalentConstraint(new[] {
-                new ShippingOption {Description = "First-Class Mail", Price = 1.06},
-                new ShippingOption {Description = "Media Mail<sup>®</sup>", Price = 6.52},
-                new ShippingOption {Description = "Library Mail", Price = 6.21}
+                new ShippingOption {Description = "First-Class Mail", Price = 1.06M},
+                new ShippingOption {Description = "Media Mail<sup>®</sup>", Price = 6.52M},
+                new ShippingOption {Description = "Library Mail", Price = 6.21M}
             }).Using(new ShippingOption.ShippingOptionComparer()));
         }
 
@@ -316,7 +316,7 @@ namespace Nwazet.Commerce.Tests {
         public void DomesticServicePricesWithRegisteredMailYieldsBumpedPrice() {
             var uspsService = BuildFakeUspsService();
             var price = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "United States", 5, 3, 2, "98052", "90220", false, false,
                 true, false, false, false, false).First();
             Assert.That(price.Price, Is.EqualTo(1.06 + 11.20));
@@ -327,7 +327,7 @@ namespace Nwazet.Commerce.Tests {
         public void DomesticServicePricesWithInsuranceYieldsBumpedPrice() {
             var uspsService = BuildFakeUspsService();
             var price = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "United States", 5, 3, 2, "98052", "90220", false, false,
                 false, true, false, false, false).First();
             Assert.That(price.Price, Is.EqualTo(1.06 + 1.95));
@@ -338,10 +338,10 @@ namespace Nwazet.Commerce.Tests {
         public void DomesticServicePricesWithReturnReceiptYieldsBumpedPrice() {
             var uspsService = BuildFakeUspsService();
             var price = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "United States", 5, 3, 2, "98052", "90220", false, false,
                 false, false, true, false, false).First();
-            Assert.That(price.Price, Is.EqualTo(24.85 + 2.55));
+            Assert.That(price.Price, Is.EqualTo(24.85M + 2.55M));
             Assert.That(price.Description, Is.EqualTo("Priority Mail<sup>®</sup>"));
         }
 
@@ -349,7 +349,7 @@ namespace Nwazet.Commerce.Tests {
         public void DomesticServicePricesWithCertificateOfMailingYieldsBumpedPrice() {
             var uspsService = BuildFakeUspsService();
             var price = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "United States", 5, 3, 2, "98052", "90220", false, false,
                 false, false, false, true, false).First();
             Assert.That(price.Price, Is.EqualTo(1.06 + 1.20));
@@ -360,7 +360,7 @@ namespace Nwazet.Commerce.Tests {
         public void DomesticServicePricesWithConfirmationYieldsBumpedPrice() {
             var uspsService = BuildFakeUspsService();
             var price = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "United States", 5, 3, 2, "98052", "90220", false, false,
                 false, false, false, false, true).First();
             Assert.That(price.Price, Is.EqualTo(24.85 + 1.25));
@@ -371,10 +371,10 @@ namespace Nwazet.Commerce.Tests {
         public void DomesticServicePricesWithSeveralOptionsYieldsCombinedPrice() {
             var uspsService = BuildFakeUspsService();
             var price = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "United States", 5, 3, 2, "98052", "90220", false, false,
                 true, true, false, true, false).First();
-            Assert.That(price.Price, Is.EqualTo(1.06 + 11.20 + 1.95 + 1.20));
+            Assert.That(price.Price, Is.EqualTo(1.06M + 11.20M + 1.95M + 1.20M));
             Assert.That(price.Description, Is.EqualTo("First-Class Mail"));
         }
 
@@ -382,7 +382,7 @@ namespace Nwazet.Commerce.Tests {
         public void DomesticServicePricesWithUnavailableOptionsYieldsNothing() {
             var uspsService = BuildFakeUspsService();
             var prices = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "United States", 5, 3, 2, "98052", "90220", false, false,
                 true, true, true, true, false);
             Assert.That(prices, Is.Empty);

--- a/Nwazet.Commerce.Tests/UspsServiceInternationalTests.cs
+++ b/Nwazet.Commerce.Tests/UspsServiceInternationalTests.cs
@@ -18,7 +18,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalRequestDocumentIsCorrectlyBuilt() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 5, 3, 2, "90220", false, false,
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 5, 3, 2, "90220", false, false,
                 false, false, false, false, false);
 
             Assert.That(requestDocument.Name.LocalName, Is.EqualTo("IntlRateV2Request"));
@@ -49,19 +49,19 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalRequestSmallPackageIsNotMachinable() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 5, 3, 2, "90220");
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 5, 3, 2, "90220");
 
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
 
             requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 6, 1, 2, "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 6, 1, 2, "90220",
                 false, false, false, false, false);
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
 
             requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 6, 0, 3, "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 6, 0, 3, "90220",
                 false, false, false, false, false);
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
@@ -70,17 +70,17 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalRequestLargePackageIsNotMachinable() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 28, 17, 17, "90220");
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 28, 17, 17, "90220");
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
 
             requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 27, 18, 17, "90220");
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 27, 18, 17, "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
 
             requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 27, 17, 18, "90220");
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 27, 17, 18, "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
         }
@@ -88,7 +88,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalRequestLightPackageIsNotMachinable() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 5, 1030.54, "Big Box", "France", 28, 17, 17, "90220");
+                "Joe User", 5, 1030.54M, "Big Box", "France", 28, 17, 17, "90220");
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
         }
@@ -96,7 +96,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalRequestHeavyPackageIsNotMachinable() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 401, 1030.54, "Big Box", "France", 28, 17, 17, "90220");
+                "Joe User", 401, 1030.54M, "Big Box", "France", 28, 17, 17, "90220");
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("false"));
         }
@@ -104,27 +104,27 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalRequestMachinablePackageIsMachinable() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 27, 17, 17, "90220");
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 27, 17, 17, "90220");
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("true"));
 
             requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 6, 1, 3, "90220");
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 6, 1, 3, "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("true"));
 
             requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 10, 10, 10, "90220");
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 10, 10, 10, "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("true"));
 
             requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 6, 1030.54, "Big Box", "France", 10, 10, 10, "90220");
+                "Joe User", 6, 1030.54M, "Big Box", "France", 10, 10, 10, "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("true"));
 
             requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 400, 1030.54, "Big Box", "France", 10, 10, 10, "90220");
+                "Joe User", 400, 1030.54M, "Big Box", "France", 10, 10, 10, "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Machinable").Value, Is.EqualTo("true"));
         }
@@ -132,17 +132,17 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalRequestLargePackageIsLarge() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 40, 1030.54, "Big Box", "France", 13, 12, 12, "90220");
+                "Joe User", 40, 1030.54M, "Big Box", "France", 13, 12, 12, "90220");
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Size").Value, Is.EqualTo("LARGE"));
 
             requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 40, 1030.54, "Big Box", "France", 12, 13, 12, "90220");
+                "Joe User", 40, 1030.54M, "Big Box", "France", 12, 13, 12, "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Size").Value, Is.EqualTo("LARGE"));
 
             requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 40, 1030.54, "Big Box", "France", 12, 12, 13, "90220");
+                "Joe User", 40, 1030.54M, "Big Box", "France", 12, 12, 13, "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Size").Value, Is.EqualTo("LARGE"));
         }
@@ -150,12 +150,12 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalRequestRegularPackageIsNotLarge() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 40, 1030.54, "Big Box", "France", 12, 12, 12, "90220");
+                "Joe User", 40, 1030.54M, "Big Box", "France", 12, 12, 12, "90220");
             var package = requestDocument.Element("Package");
             Assert.That(package.Element("Size").Value, Is.EqualTo("REGULAR"));
 
             requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 40, 1030.54, "Big Box", "France", 5, 5, 5, "90220");
+                "Joe User", 40, 1030.54M, "Big Box", "France", 5, 5, 5, "90220");
             package = requestDocument.Element("Package");
             Assert.That(package.Element("Size").Value, Is.EqualTo("REGULAR"));
         }
@@ -163,7 +163,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalRegisteredMailIsExpressed() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 5, 3, 2, "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 5, 3, 2, "90220",
                 false, false, true, false, false, false, false);
 
             var package = requestDocument.Element("Package");
@@ -175,7 +175,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalInsuranceIsExpressed() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 5, 3, 2, "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 5, 3, 2, "90220",
                 false, false, false, true, false, false, false);
 
             var package = requestDocument.Element("Package");
@@ -187,7 +187,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalReturnReceiptIsExpressed() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 5, 3, 2, "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 5, 3, 2, "90220",
                 false, false, false, false, true, false, false);
 
             var package = requestDocument.Element("Package");
@@ -199,7 +199,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalCertificateOfMailingIsExpressed() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 5, 3, 2, "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 5, 3, 2, "90220",
                 false, false, false, false, false, true, false);
 
             var package = requestDocument.Element("Package");
@@ -211,7 +211,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalElectronicConfirmationIsExpressed() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 5, 3, 2, "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 5, 3, 2, "90220",
                 false, false, false, false, false, false, true);
 
             var package = requestDocument.Element("Package");
@@ -223,7 +223,7 @@ namespace Nwazet.Commerce.Tests {
         [Test]
         public void InternationalServicesAreExpressed() {
             var requestDocument = UspsService.BuildInternationalShippingRequestDocument(
-                "Joe User", 45.3, 1030.54, "Big Box", "France", 5, 3, 2, "90220",
+                "Joe User", 45.3, 1030.54M, "Big Box", "France", 5, 3, 2, "90220",
                 false, false, true, true, true, true, true);
 
             var package = requestDocument.Element("Package");
@@ -241,28 +241,28 @@ namespace Nwazet.Commerce.Tests {
         public void InternationalServicePricesReturnsInternationalPrices() {
             var uspsService = BuildFakeUspsService();
             var prices = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "France", 5, 3, 2, "98052", null, false, false,
                 false, false, false, false, false).ToList();
             Assert.That(prices.Count, Is.EqualTo(17));
             Assert.That(prices, new CollectionEquivalentConstraint(new[] {
-                new ShippingOption {Description = "Global Express Guaranteed<sup>®</sup> (GXG)**; 1 - 3 business days", Price = 117.05},
-                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 117.05},
-                new ShippingOption {Description = "Express Mail<sup>®</sup> International; 3 - 5 business days", Price = 96.30},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> International; 6 - 10 business days", Price = 62.15},
-                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 104.50},
-                new ShippingOption {Description = "Express Mail<sup>®</sup> International; 3 - 5 business days", Price = 46.00},
-                new ShippingOption {Description = "Express Mail<sup>®</sup> International Flat Rate Envelope; 3 - 5 business days", Price = 44.95},
-                new ShippingOption {Description = "Express Mail<sup>®</sup> International Legal Flat Rate Envelope; 3 - 5 business days", Price = 44.95},
-                new ShippingOption {Description = "Express Mail<sup>®</sup> International Padded Flat Rate Envelope; 3 - 5 business days", Price = 44.95},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> International; 6 - 10 business days", Price = 36.75},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> International Flat Rate Envelope**; 6 - 10 business days", Price = 23.95},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> International Legal Flat Rate Envelope**; 6 - 10 business days", Price = 23.95},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> International Padded Flat Rate Envelope**; 6 - 10 business days", Price = 23.95},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> International Gift Card Flat Rate Envelope**; 6 - 10 business days", Price = 23.95},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> International Small Flat Rate Envelope**; 6 - 10 business days", Price = 23.95},
-                new ShippingOption {Description = "Priority Mail<sup>®</sup> International Window Flat Rate Envelope**; 6 - 10 business days", Price = 23.95},
-                new ShippingOption {Description = "First-Class Mail<sup>®</sup> International Letter**; Varies by country", Price = 2.70}
+                new ShippingOption {Description = "Global Express Guaranteed<sup>®</sup> (GXG)**; 1 - 3 business days", Price = 117.05M},
+                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 117.05M},
+                new ShippingOption {Description = "Express Mail<sup>®</sup> International; 3 - 5 business days", Price = 96.30M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> International; 6 - 10 business days", Price = 62.15M},
+                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 104.50M},
+                new ShippingOption {Description = "Express Mail<sup>®</sup> International; 3 - 5 business days", Price = 46.00M},
+                new ShippingOption {Description = "Express Mail<sup>®</sup> International Flat Rate Envelope; 3 - 5 business days", Price = 44.95M},
+                new ShippingOption {Description = "Express Mail<sup>®</sup> International Legal Flat Rate Envelope; 3 - 5 business days", Price = 44.95M},
+                new ShippingOption {Description = "Express Mail<sup>®</sup> International Padded Flat Rate Envelope; 3 - 5 business days", Price = 44.95M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> International; 6 - 10 business days", Price = 36.75M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> International Flat Rate Envelope**; 6 - 10 business days", Price = 23.95M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> International Legal Flat Rate Envelope**; 6 - 10 business days", Price = 23.95M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> International Padded Flat Rate Envelope**; 6 - 10 business days", Price = 23.95M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> International Gift Card Flat Rate Envelope**; 6 - 10 business days", Price = 23.95M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> International Small Flat Rate Envelope**; 6 - 10 business days", Price = 23.95M},
+                new ShippingOption {Description = "Priority Mail<sup>®</sup> International Window Flat Rate Envelope**; 6 - 10 business days", Price = 23.95M},
+                new ShippingOption {Description = "First-Class Mail<sup>®</sup> International Letter**; Varies by country", Price = 2.70M}
             }).Using(new ShippingOption.ShippingOptionComparer()));
         }
 
@@ -270,14 +270,14 @@ namespace Nwazet.Commerce.Tests {
         public void InternationalServicePricesWithValidationExpressionSelectsMatchingMethods() {
             var uspsService = BuildFakeUspsService();
             var prices = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", "GXG", null,
+                "Joe User", 45.3, 1030.54M, "Big Box", "GXG", null,
                 "France", 5, 3, 2, "98052", null, false, false,
                 false, false, false, false, false).ToList();
             Assert.That(prices.Count, Is.EqualTo(3));
             Assert.That(prices, new CollectionEquivalentConstraint(new[] {
-                new ShippingOption {Description = "Global Express Guaranteed<sup>®</sup> (GXG)**; 1 - 3 business days", Price = 117.05},
-                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 117.05},
-                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 104.50}
+                new ShippingOption {Description = "Global Express Guaranteed<sup>®</sup> (GXG)**; 1 - 3 business days", Price = 117.05M},
+                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 117.05M},
+                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 104.50M}
             }).Using(new ShippingOption.ShippingOptionComparer()));
         }
 
@@ -285,14 +285,14 @@ namespace Nwazet.Commerce.Tests {
         public void InternationalServicePricesWithExclusionExpressionExcludesMatchingMethods() {
             var uspsService = BuildFakeUspsService();
             var prices = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, "Mail",
+                "Joe User", 45.3, 1030.54M, "Big Box", null, "Mail",
                 "France", 5, 3, 2, "98052", null, false, false,
                 false, false, false, false, false).ToList();
             Assert.That(prices.Count, Is.EqualTo(3));
             Assert.That(prices, new CollectionEquivalentConstraint(new[] {
-                new ShippingOption {Description = "Global Express Guaranteed<sup>®</sup> (GXG)**; 1 - 3 business days", Price = 117.05},
-                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 117.05},
-                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 104.50}
+                new ShippingOption {Description = "Global Express Guaranteed<sup>®</sup> (GXG)**; 1 - 3 business days", Price = 117.05M},
+                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 117.05M},
+                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 104.50M}
             }).Using(new ShippingOption.ShippingOptionComparer()));
         }
 
@@ -300,13 +300,13 @@ namespace Nwazet.Commerce.Tests {
         public void InternationalServicePricesWithExclusionAndValidationExpressionsYieldsTheRightMethods() {
             var uspsService = BuildFakeUspsService();
             var prices = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", "USPS", "Mail",
+                "Joe User", 45.3, 1030.54M, "Big Box", "USPS", "Mail",
                 "France", 5, 3, 2, "98052", null, false, false,
                 false, false, false, false, false).ToList();
             Assert.That(prices.Count, Is.EqualTo(2));
             Assert.That(prices, new CollectionEquivalentConstraint(new[] {
-                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 117.05},
-                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 104.50}
+                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 117.05M},
+                new ShippingOption {Description = "USPS GXG<sup>™</sup> Envelopes**; 1 - 3 business days", Price = 104.50M}
             }).Using(new ShippingOption.ShippingOptionComparer()));
         }
 
@@ -314,7 +314,7 @@ namespace Nwazet.Commerce.Tests {
         public void InternationalServicePricesWithRegisteredMailYieldsBumpedPrice() {
             var uspsService = BuildFakeUspsService();
             var price = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "France", 5, 3, 2, "98052", null, false, false,
                 true, false, false, false, false).First();
             Assert.That(price.Price, Is.EqualTo(117.05 + 1.50));
@@ -325,7 +325,7 @@ namespace Nwazet.Commerce.Tests {
         public void InternationalServicePricesWithInsuranceYieldsBumpedPrice() {
             var uspsService = BuildFakeUspsService();
             var price = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "France", 5, 3, 2, "98052", null, false, false,
                 false, true, false, false, false).First();
             Assert.That(price.Price, Is.EqualTo(117.05 + 1.00));
@@ -336,7 +336,7 @@ namespace Nwazet.Commerce.Tests {
         public void InternationalServicePricesWithReturnReceiptYieldsBumpedPrice() {
             var uspsService = BuildFakeUspsService();
             var price = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "France", 5, 3, 2, "98052", null, false, false,
                 false, false, true, false, false).First();
             Assert.That(price.Price, Is.EqualTo(117.05 + 1.70));
@@ -347,7 +347,7 @@ namespace Nwazet.Commerce.Tests {
         public void InternationalServicePricesWithCertificateOfMailingYieldsBumpedPrice() {
             var uspsService = BuildFakeUspsService();
             var price = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "France", 5, 3, 2, "98052", null, false, false,
                 false, false, false, true, false).First();
             Assert.That(price.Price, Is.EqualTo(117.05 + 1.18));
@@ -358,7 +358,7 @@ namespace Nwazet.Commerce.Tests {
         public void InternationalServicePricesWithConfirmationYieldsBumpedPrice() {
             var uspsService = BuildFakeUspsService();
             var price = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "France", 5, 3, 2, "98052", null, false, false,
                 false, false, false, false, true).First();
             Assert.That(price.Price, Is.EqualTo(117.05 + 1.04));
@@ -369,7 +369,7 @@ namespace Nwazet.Commerce.Tests {
         public void InternationalServicePricesWithSeveralOptionsYieldsCombinedPrice() {
             var uspsService = BuildFakeUspsService();
             var price = uspsService.Prices(
-                "Joe User", 45.3, 1030.54, "Big Box", null, null,
+                "Joe User", 45.3, 1030.54M, "Big Box", null, null,
                 "France", 5, 3, 2, "98052", null, false, false,
                 true, true, false, true, false).First();
             Assert.That(price.Price, Is.EqualTo(117.05 + 1.50 + 1.00 + 1.18));

--- a/Services/UspsService.cs
+++ b/Services/UspsService.cs
@@ -9,6 +9,7 @@ using Nwazet.Commerce.Models;
 using Orchard;
 using Orchard.ContentManagement;
 using Orchard.Environment.Extensions;
+using System.Globalization;
 
 namespace Nwazet.Commerce.Services {
     [OrchardFeature("Usps.Shipping")]
@@ -177,7 +178,7 @@ namespace Nwazet.Commerce.Services {
                                        new XElement("Ounces", ounces.ToString("G2")),
                                        new XElement("Machinable", machinable),
                                        new XElement("MailType", "Package"),
-                                       new XElement("ValueOfContents", valueOfContents.ToString("F2")),
+                                       new XElement("ValueOfContents", valueOfContents.ToString("F2", CultureInfo.GetCultureInfo("en-US"))), //assume dollars
                                        new XElement("Country", country),
                                        new XElement("Container", container),
                                        new XElement("Size", large ? "LARGE" : "REGULAR"),
@@ -306,35 +307,35 @@ namespace Nwazet.Commerce.Services {
                         if (basePriceNode == null) {
                             throw new InvalidOperationException("USPS rate not found in response");
                         }
-                        var price = Decimal.Parse(basePriceNode.Value);
+                        var price = decimal.Parse(basePriceNode.Value, CultureInfo.GetCultureInfo("en-US")); //US web service
                         if (registeredMail) {
                             var serviceNode = FindDomesticServiceNode(s, RegisteredMailDomestic);
                             if (serviceNode == null) return Nothing;
-                            price += decimal.Parse(serviceNode.Value);
+                            price += decimal.Parse(serviceNode.Value, CultureInfo.GetCultureInfo("en-US"));
                             AddServiceNameToDescription(serviceNode, descriptionBuilder);
                         }
                         if (insurance) {
                             var serviceNode = FindDomesticServiceNode(s, InsuranceDomestic);
                             if (serviceNode == null) return Nothing;
-                            price += decimal.Parse(serviceNode.Value);
+                            price += decimal.Parse(serviceNode.Value, CultureInfo.GetCultureInfo("en-US"));
                             AddServiceNameToDescription(serviceNode, descriptionBuilder);
                         }
                         if (returnReceipt) {
                             var serviceNode = FindDomesticServiceNode(s, ReturnReceiptDomestic);
                             if (serviceNode == null) return Nothing;
-                            price += decimal.Parse(serviceNode.Value);
+                            price += decimal.Parse(serviceNode.Value, CultureInfo.GetCultureInfo("en-US"));
                             AddServiceNameToDescription(serviceNode, descriptionBuilder);
                         }
                         if (certificateOfMailing) {
                             var serviceNode = FindDomesticServiceNode(s, CertificateOfMailingDomestic);
                             if (serviceNode == null) return Nothing;
-                            price += decimal.Parse(serviceNode.Value);
+                            price += decimal.Parse(serviceNode.Value, CultureInfo.GetCultureInfo("en-US"));
                             AddServiceNameToDescription(serviceNode, descriptionBuilder);
                         }
                         if (electronicConfirmation) {
                             var serviceNode = FindDomesticServiceNode(s, ElectronicConfirmationDomestic);
                             if (serviceNode == null) return Nothing;
-                            price += decimal.Parse(serviceNode.Value);
+                            price += decimal.Parse(serviceNode.Value, CultureInfo.GetCultureInfo("en-US"));
                             AddServiceNameToDescription(serviceNode, descriptionBuilder);
                         }
                         return new[] {
@@ -372,35 +373,35 @@ namespace Nwazet.Commerce.Services {
                     if (basePriceNode == null) {
                         throw new InvalidOperationException("USPS rate not found in response");
                     }
-                    var price = decimal.Parse(basePriceNode.Value);
+                    var price = decimal.Parse(basePriceNode.Value, CultureInfo.GetCultureInfo("en-US")); //US webservice
                     if (registeredMail) {
                         var serviceNode = FindInternationalServiceNode(s, RegisteredMailInternational);
                         if (serviceNode == null) return Nothing;
-                        price += decimal.Parse(serviceNode.Value);
+                        price += decimal.Parse(serviceNode.Value, CultureInfo.GetCultureInfo("en-US"));
                         AddServiceNameToDescription(serviceNode, descriptionBuilder);
                     }
                     if (insurance) {
                         var serviceNode = FindInternationalServiceNode(s, InsuranceInternational);
                         if (serviceNode == null) return Nothing;
-                        price += decimal.Parse(serviceNode.Value);
+                        price += decimal.Parse(serviceNode.Value, CultureInfo.GetCultureInfo("en-US"));
                         AddServiceNameToDescription(serviceNode, descriptionBuilder);
                     }
                     if (returnReceipt) {
                         var serviceNode = FindInternationalServiceNode(s, ReturnReceiptInternational);
                         if (serviceNode == null) return Nothing;
-                        price += decimal.Parse(serviceNode.Value);
+                        price += decimal.Parse(serviceNode.Value, CultureInfo.GetCultureInfo("en-US"));
                         AddServiceNameToDescription(serviceNode, descriptionBuilder);
                     }
                     if (certificateOfMailing) {
                         var serviceNode = FindInternationalServiceNode(s, CertificateOfMailingInternational);
                         if (serviceNode == null) return Nothing;
-                        price += decimal.Parse(serviceNode.Value);
+                        price += decimal.Parse(serviceNode.Value, CultureInfo.GetCultureInfo("en-US"));
                         AddServiceNameToDescription(serviceNode, descriptionBuilder);
                     }
                     if (electronicConfirmation) {
                         var serviceNode = FindInternationalServiceNode(s, ElectronicConfirmationInternational);
                         if (serviceNode == null) return Nothing;
-                        price += decimal.Parse(serviceNode.Value);
+                        price += decimal.Parse(serviceNode.Value, CultureInfo.GetCultureInfo("en-US"));
                         AddServiceNameToDescription(serviceNode, descriptionBuilder);
                     }
 


### PR DESCRIPTION
Fixes #109 

Some tests required an updated because of the change to decimal for prices.

A couple more corrections ewre required to handle different formatting of numbers in different cultures.
I updated UspsService so it always uses the en-US culture to parse strings. However, I don't think the same assumption can be made for ZipCodeTaxPart in the method where it parses the rates.