### PR TITLE
WishListUIServces not throwing Exception anymore

### DIFF
--- a/Services/WishListsUIServices.cs
+++ b/Services/WishListsUIServices.cs
@@ -39,7 +39,7 @@ namespace Nwazet.Commerce.Services {
 
         public dynamic CreateShape(IUser user, ProductPart product = null) {
             if (user == null) {
-                throw new ArgumentNullException("user");
+                return null;
             }
 
             var productId = 0;
@@ -67,7 +67,7 @@ namespace Nwazet.Commerce.Services {
 
         public dynamic SettingsShape(IUser user, int wishListId = 0) {
             if (user == null) {
-                throw new ArgumentNullException("user");
+                return null;
             }
             //build the settings shape for each wishlist
             var settingsShapes = new List<dynamic>();


### PR DESCRIPTION
Fixes #138
Instead of throwing an ArgumentNullException, if the user is null the methods now return null. This seems to not break anything, because the output of these methods is currently not used anywhere the user may be null, by default. Safely using these methods will now require null-checks.