### PR TITLE
Added missing dependency Orchard.Localization

### DIFF
--- a/Module.txt
+++ b/Module.txt
@@ -75,7 +75,7 @@ Features:
 		Name: Nwazet Advanced SKU Management
         Description: Makes the use of SKUs more advanced, by providing options related to their uniqueness and automatic generation
         Category: Commerce
-        Dependencies: Nwazet.Commerce
+        Dependencies: Nwazet.Commerce, Orchard.Localization
 	Nwazet.CurrencyProviderBySiteSetting:
 		Name: SiteSettings Currency Provider
         Description: Enables a currency provider for the site based on a site's setting


### PR DESCRIPTION
The Nwazet.AdvancedSKUManagement is dependent upon Orchard.Localization and the dependency was missing, causing an error where the site won't even start if Nwazet.AdvancedSKUManagement is enabled without this change.